### PR TITLE
New linter: SpacesForIndentation

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -79,6 +79,9 @@ linters:
     enabled: true
     style: space
 
+  SpacesForIndentation:
+    enabled: false
+
   TagName:
     enabled: true
 

--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -19,6 +19,7 @@ Below is a list of linters supported by `haml-lint`, ordered alphabetically.
 * [RubyComments](#rubycomments)
 * [SpaceBeforeScript](#spacebeforescript)
 * [SpaceInsideHashAttributes](#spaceinsidehashattributes)
+* [SpacesForIndentation](#spacesforindentation)
 * [TagName](#tagname)
 * [TrailingWhitespace](#trailingwhitespace)
 * [UnnecessaryInterpolation](#unnecessaryinterpolation)
@@ -446,6 +447,11 @@ hash attributes braces**
 This offers the ability to ensure consistency of Haml hash
 attributes style with ruby hash literal style (compare with
 the Style/SpaceInsideHashLiteralBraces cop in Rubocop).
+
+## SpacesForIndentation
+
+Check that hard tabs are not used for indentation.  Instead, spaces should be.
+Disabled by default, since tabs are actually allowed in HAML.
 
 ## TagName
 

--- a/lib/haml_lint/linter/spaces_for_indentation.rb
+++ b/lib/haml_lint/linter/spaces_for_indentation.rb
@@ -1,0 +1,16 @@
+module HamlLint
+  # Checks that indentation doesn't use tabs
+  class Linter::SpacesForIndentation < Linter
+    include LinterRegistry
+
+    def visit_root(_node)
+      dummy_node = Struct.new(:line)
+
+      document.source_lines.each_with_index do |line, index|
+        next unless line =~ /^\s*\t/
+
+        record_lint dummy_node.new(index + 1), 'Line contains tabs in indentation'
+      end
+    end
+  end
+end

--- a/spec/haml_lint/linter/spaces_for_indentation_spec.rb
+++ b/spec/haml_lint/linter/spaces_for_indentation_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe HamlLint::Linter::SpacesForIndentation do
+  include_context 'linter'
+
+  # rubocop and overcomit HardTab checks don't like tabs either, but they don't
+  # check for hex, so use that to avoid triggering them
+  let(:tab) { "\x09" }
+
+  context 'when line contains just a tab in its indentation' do
+    let(:haml) { <<-HAML }
+      %span
+#{tab * 4}- bar
+    HAML
+
+    it { should report_lint line: 2 }
+  end
+
+  context 'when line contains spaces and a tab in its indentation' do
+    let(:haml) { <<-HAML }
+      %span
+      #{tab}- bar
+    HAML
+
+    it { should report_lint line: 2 }
+  end
+
+  context 'when line contains no indentation' do
+    let(:haml) { '- foo_bar' }
+
+    it { should_not report_lint }
+  end
+
+  context 'when line contains a tabs but not in indentation' do
+    let(:haml) { '  = "\t"' }
+
+    it { should_not report_lint }
+  end
+
+  context 'when line contains no tabs in indentation' do
+    let(:haml) { '  - foo_bar' }
+
+    it { should_not report_lint }
+  end
+end


### PR DESCRIPTION
Disabled by default, since tabs are acceptable in HAML, but folks may
want to enable this to enforce spaces-only.