### PR TITLE
Output dummy puts statements for tag closing nodes

### DIFF
--- a/lib/haml_lint/haml_visitor.rb
+++ b/lib/haml_lint/haml_visitor.rb
@@ -14,13 +14,14 @@ module HamlLint
         visit_children(node) if descend == :children
       end
 
-      method = "visit_#{node_name(node)}"
-      send(method, node, &block) if respond_to?(method, true)
+      safe_send("visit_#{node_name(node)}", node, &block)
 
       # Visit all children by default unless the block was invoked (indicating
       # the user intends to not recurse further, or wanted full control over
       # when the children were visited).
       visit_children(node) unless block_called
+
+      safe_send("after_visit_#{node_name(node)}", node, &block)
     end
 
     def visit_children(parent)
@@ -31,6 +32,10 @@ module HamlLint
 
     def node_name(node)
       node.type
+    end
+
+    def safe_send(name, *args, &block)
+      send(name, *args, &block) if respond_to?(name, true)
     end
   end
 end

--- a/lib/haml_lint/ruby_extractor.rb
+++ b/lib/haml_lint/ruby_extractor.rb
@@ -84,6 +84,11 @@ module HamlLint
       add_line(code, node) unless code.empty?
     end
 
+    def after_visit_tag(node)
+      # We add a dummy puts statement for closing tag.
+      add_line("puts # #{node.tag_name}/", node)
+    end
+
     def visit_script(node)
       code = node.text
       add_line(code.strip, node)

--- a/spec/haml_lint/linter/rubocop_spec.rb
+++ b/spec/haml_lint/linter/rubocop_spec.rb
@@ -30,7 +30,7 @@ describe HamlLint::Linter::RuboCop do
   end
 
   context 'when RuboCop reports offences' do
-    let(:line) { 4 }
+    let(:line) { 6 }
     let(:message) { 'Lint message' }
     let(:cop_name) { 'Lint/SomeCopName' }
 


### PR DESCRIPTION
This fixes a bug where code like the following:

```haml
  - [1, 2, 3].each do |value|
    %div
      - if value == 0
        %div
        %div
        %div
```

...would incorrectly report a lint via the `Style/Next` cop like following:

```
foo.haml:1 [W] RuboCop: Use `next` to skip iteration.
```