### PR TITLE
Simplify tempfile path in Rubocop linter

### DIFF
--- a/lib/haml_lint/linter/rubocop.rb
+++ b/lib/haml_lint/linter/rubocop.rb
@@ -28,10 +28,9 @@ module HamlLint
       rubocop = ::RuboCop::CLI.new
 
       original_filename = document.file || 'ruby_script'
-      filename = "#{File.basename(original_filename)}.haml_lint.tmp"
-      directory = File.dirname(original_filename)
+      filename = File.basename(original_filename)
 
-      Tempfile.open(filename, directory) do |f|
+      Tempfile.open(filename) do |f|
         begin
           f.write(ruby)
           f.close


### PR DESCRIPTION
Why:

* Ruby's `Tempfile` generates unique names for files in the system's
  tmp directory.
* Providing a specific path for the temfile will fail in situations
  where the that directory doesn't exist on the filesystem.
  This is the case is virtual situations, like with Hound CI.