### PR TITLE
Add explicit dependency on parser

### DIFF
--- a/haml_lint.gemspec
+++ b/haml_lint.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rake', '~> 10.0'
   s.add_dependency 'rubocop', '>= 0.36.0'
   s.add_dependency 'sysexits', '~> 1.1'
+  s.add_dependency 'parser', '>= 2.0.0'
 
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its', '~> 1.0'


### PR DESCRIPTION
We use this gem here: lib/haml_lint/ruby_parser.rb, we should also require it.

In my set up (after updating bundler and some other gems) it could not find the parser gem.
Then I found out that haml_lint uses it, but does not list it as a dependency.