### PR TITLE
Ignore the ElseAlignment and FrozenStringLiteralComment cops by default

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -64,8 +64,10 @@ linters:
       - Metrics/LineLength
       - Style/AlignParameters
       - Style/BlockNesting
+      - Style/ElseAlignment
       - Style/FileName
       - Style/FinalNewline
+      - Style/FrozenStringLiteralComment
       - Style/IfUnlessModifier
       - Style/IndentationWidth
       - Style/Next


### PR DESCRIPTION
These two cops which recently have been added to Rubocop do not make
sense for HAML files.

Fixes #114
Fixes #115