### PR TITLE
Fix middle-of-lign equals sign in UnnecessaryStringOutput

### DIFF
--- a/lib/haml_lint/linter/unnecessary_string_output.rb
+++ b/lib/haml_lint/linter/unnecessary_string_output.rb
@@ -22,7 +22,7 @@ module HamlLint
     def visit_script(node)
       # Some script nodes created by the HAML parser aren't actually script
       # nodes declared via the `=` marker. Check for it.
-      return if node.source_code !~ /\s*=/
+      return if node.source_code !~ /\A\s*=/
 
       if outputs_string_literal?(node)
         record_lint(node, MESSAGE)

--- a/spec/haml_lint/linter/unnecessary_string_output_spec.rb
+++ b/spec/haml_lint/linter/unnecessary_string_output_spec.rb
@@ -113,4 +113,10 @@ describe HamlLint::Linter::UnnecessaryStringOutput do
 
     it { should_not report_lint }
   end
+
+  context 'when equals sign appears in the middle of the line' do
+    let(:haml) { '#{quantity} x #{amount} = #{price}' }
+
+    it { should_not report_lint }
+  end
 end


### PR DESCRIPTION
Just stumbled upon this edge case in a project.

Note: I wondered whether changing `unnecessary_string_output.rb:25` to use `\A\s*=` is overly specific, since it excludes lines that begin with a tag, e.g. `%p= script`. But then, those lines are apparently not parsed as script nodes anyway (change `haml_visitor_spec.rb:120` to `%p= scriptB`, and that spec fails), so they would in any event never be considered by UnnecessaryStringOutput. Hope the reasoning is correct, otherwise please let me know.