### PR TITLE
Front matter fix

### DIFF
--- a/lib/haml_lint/document.rb
+++ b/lib/haml_lint/document.rb
@@ -98,20 +98,22 @@ module HamlLint
 
     # Removes YAML frontmatter
     def strip_frontmatter(source)
-      if config['skip_frontmatter'] &&
-        source =~ /
-          # From the start of the string
-          \A
-          # First-capture match --- followed by optional whitespace up
-          # to a newline then 0 or more chars followed by an optional newline.
-          # This matches the --- and the contents of the frontmatter
-          (---\s*\n.*?\n?)
-          # From the start of the line
-          ^
-          # Second capture match --- or ... followed by optional whitespace
-          # and newline. This matches the closing --- for the frontmatter.
-          (---|\.\.\.)\s*$\n?/mx
-        source = $POSTMATCH
+      frontmatter = /
+        # From the start of the string
+        \A
+        # First-capture match --- followed by optional whitespace up
+        # to a newline then 0 or more chars followed by an optional newline.
+        # This matches the --- and the contents of the frontmatter
+        (---\s*\n.*?\n?)
+        # From the start of the line
+        ^
+        # Second capture match --- or ... followed by optional whitespace
+        # and newline. This matches the closing --- for the frontmatter.
+        (---|\.\.\.)\s*$\n?/mx
+
+      if config['skip_frontmatter'] && match = source.match(frontmatter)
+        newlines = match[0].count("\n")
+        source.sub!(frontmatter, "\n" * newlines)
       end
 
       source

--- a/spec/haml_lint/document_spec.rb
+++ b/spec/haml_lint/document_spec.rb
@@ -57,6 +57,10 @@ describe HamlLint::Document do
           subject.source.should_not include '---'
           subject.source.should include '%head'
         end
+
+        it 'reports line numbers as if frontmatter was not removed' do
+          expect(subject.tree.children.first.line).to eq(4)
+        end
       end
 
       context 'and the source does not contain frontmatter' do


### PR DESCRIPTION
Related to #124.

My solution is to replace the frontmatter with newlines.

Another idea would be to introduce an `offset` parameter with number of frontmatter lines and pass that to the parser/nodes, but that would require much more work. I'm not aware that replacing the frontmatter with empty lines would make lints go off, despite the HAML containing unnecessary whitespace in the head.

some.haml:
``` 
---
foo: 42
--- 
%p Hello
```

With this PR merged is analyzed as:
``` 


 
%p Hello
```