### PR TITLE
Add fail level option to integrate with any CI tool

### DIFF
--- a/lib/haml_lint.rb
+++ b/lib/haml_lint.rb
@@ -19,6 +19,7 @@ require 'haml_lint/file_finder'
 require 'haml_lint/runner'
 require 'haml_lint/utils'
 require 'haml_lint/version'
+require 'haml_lint/severity'
 
 # Load all parse tree node classes
 require 'haml_lint/tree/node'

--- a/lib/haml_lint/lint.rb
+++ b/lib/haml_lint/lint.rb
@@ -28,14 +28,14 @@ module HamlLint
       @filename = filename
       @line     = line || 0
       @message  = message
-      @severity = severity
+      @severity = Severity.new(severity)
     end
 
     # Return whether this lint has a severity of error.
     #
     # @return [Boolean]
     def error?
-      @severity == :error
+      @severity.error?
     end
   end
 end

--- a/lib/haml_lint/options.rb
+++ b/lib/haml_lint/options.rb
@@ -45,6 +45,11 @@ module HamlLint
                 'Specify which reporter you want to use to generate the output') do |reporter|
         @options[:reporter] = load_reporter_class(reporter.capitalize)
       end
+
+      parser.on('--fail-level fail_level', String,
+                'Specify which level you want the suite to fail') do |fail_level|
+        @options[:fail_level] = fail_level.to_sym
+      end
     end
 
     # Returns the class of the specified Reporter.

--- a/lib/haml_lint/rake_task.rb
+++ b/lib/haml_lint/rake_task.rb
@@ -51,6 +51,11 @@ module HamlLint
     # @return [true,false]
     attr_accessor :quiet
 
+    # Whether output from haml-lint should not be displayed to the standard out
+    # stream.
+    # @return [true,false]
+    attr_accessor :fail_level
+
     # Create the task so it exists in the current namespace.
     #
     # @param name [Symbol] task name
@@ -82,8 +87,7 @@ module HamlLint
     #
     # @param task_args [Rake::TaskArguments]
     def run_cli(task_args)
-      cli_args = ['--config', config] if config
-
+      cli_args = parse_args
       logger = quiet ? HamlLint::Logger.silent : HamlLint::Logger.new(STDOUT)
       result = HamlLint::CLI.new(logger).run(Array(cli_args) + files_to_lint(task_args))
 
@@ -117,6 +121,11 @@ module HamlLint
       description += " #{files.join(' ')}" if files.any?
       description += ' [files...]`'
       description
+    end
+
+    def parse_args
+      cli_args = config ? ['--config', config] : []
+      cli_args.concat(['--fail-level', fail_level]) if fail_level
     end
   end
 end

--- a/lib/haml_lint/report.rb
+++ b/lib/haml_lint/report.rb
@@ -3,6 +3,7 @@ module HamlLint
   class Report
     # List of lints that were found.
     attr_accessor :lints
+    attr_accessor :fail_level
 
     # List of files that were linted.
     attr_reader :files
@@ -11,13 +12,16 @@ module HamlLint
     #
     # @param lints [Array<HamlLint::Lint>] lints that were found
     # @param files [Array<String>] files that were linted
-    def initialize(lints, files)
+    def initialize(lints, files, fail_level = nil)
       @lints = lints.sort_by { |l| [l.filename, l.line] }
       @files = files
+      @fail_level = Severity.new(fail_level) if fail_level
     end
 
     def failed?
-      @lints.any?
+      return @lints.any unless @fail_level
+
+      @lints.find { |lint| lint.severity.level >= @fail_level.level }
     end
   end
 end

--- a/lib/haml_lint/runner.rb
+++ b/lib/haml_lint/runner.rb
@@ -10,6 +10,7 @@ module HamlLint
     # @option options :excluded_files [Array<String>]
     # @option options :included_linters [Array<String>]
     # @option options :excluded_linters [Array<String>]
+    # @option options :fail_level
     # @return [HamlLint::Report] a summary of all lints found
     def run(options = {})
       config = load_applicable_config(options)
@@ -21,7 +22,7 @@ module HamlLint
         collect_lints(file, linter_selector, config)
       end.flatten
 
-      HamlLint::Report.new(lints, files)
+      HamlLint::Report.new(lints, files, options[:fail_level])
     end
 
     private

--- a/lib/haml_lint/severity.rb
+++ b/lib/haml_lint/severity.rb
@@ -1,0 +1,46 @@
+module HamlLint
+  # Defines the severity class
+  class Severity
+    include Comparable
+
+    SEVERITY_WARNING = :warning
+    SEVERITY_ERROR = :error
+
+    NAMES = [SEVERITY_WARNING, SEVERITY_ERROR].freeze
+
+    attr_reader :name
+
+    # @api private
+    def initialize(name)
+      fail ArgumentError, "Unknown severity: #{name}" unless NAMES.include?(name)
+
+      @name = name.freeze
+      freeze
+    end
+
+    def level
+      NAMES.index(@name) + 1
+    end
+
+    # @api private
+    def to_s
+      @name.to_s
+    end
+
+    # @api private
+    def ==(other)
+      return @name == other if other.is_a?(Symbol)
+
+      @name == other.name
+    end
+
+    # @api private
+    def <=>(other)
+      level <=> other.level
+    end
+
+    def error?
+      @name == SEVERITY_ERROR
+    end
+  end
+end


### PR DESCRIPTION
**EPR** 
This branch will add a `fail-level` option to specify if the `lint` should fail if any `error` or `warning` is found.
Issue: https://github.com/brigade/haml-lint/issues/137

Pending tasks:
- [ ] Fix existing tests 😒 
- [ ] Add tests
