### PR TITLE
Configurable classes before ids

### DIFF
--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -67,7 +67,9 @@ assigned.
 
 ## ClassesBeforeIds
 
-List classes before IDs in tags.
+Whether classes or ID attributes should be listed first in tags.
+
+### EnforcedStyle: 'class' (default)
 
 **Bad: ID before class**
 ```haml
@@ -82,6 +84,22 @@ List classes before IDs in tags.
 These attributes should be listed in order of their specificity. Since the tag
 name (if specified) always comes first and has the lowest specificity, classes
 and then IDs should follow.
+
+### EnforcedStyle: 'id'
+
+**Bad: Class before ID**
+```haml
+%tag.class#id
+```
+
+**Good**
+```haml
+%tag#id.class
+```
+
+As IDs are more significant than classes to the element they represent, IDs
+should be listed first and then classes should follow. This gives a more
+consistent vertical alignment of IDs.
 
 ## ConsecutiveComments
 

--- a/lib/haml_lint/linter/classes_before_ids.rb
+++ b/lib/haml_lint/linter/classes_before_ids.rb
@@ -13,13 +13,7 @@ module HamlLint
       # Convert ".class#id" into [.class, #id] (preserving order)
       components = node.static_attributes_source.scan(/[.#][^.#]+/)
 
-      enforced_style = config.fetch('EnforcedStyle', 'class')
-      first, second = case enforced_style
-                      when 'id'
-                        ['#', '.']
-                      else
-                        ['.', '#']
-                      end
+      first, second = attribute_prefix_order
 
       (1...components.count).each do |index|
         next unless components[index].start_with?(first) &&
@@ -28,6 +22,18 @@ module HamlLint
         record_lint(node, 'Classes should be listed before IDs '\
                           "(#{components[index]} should precede #{components[index - 1]})")
         break
+      end
+    end
+
+    private
+
+    def attribute_prefix_order
+      enforced_style = config.fetch('EnforcedStyle', 'class')
+      case enforced_style
+      when 'id'
+        ['#', '.']
+      else
+        ['.', '#']
       end
     end
   end

--- a/lib/haml_lint/linter/classes_before_ids.rb
+++ b/lib/haml_lint/linter/classes_before_ids.rb
@@ -13,9 +13,17 @@ module HamlLint
       # Convert ".class#id" into [.class, #id] (preserving order)
       components = node.static_attributes_source.scan(/[.#][^.#]+/)
 
+      enforced_style = config.fetch('EnforcedStyle', 'class')
+      first, second = case enforced_style
+                      when 'id'
+                        ['#', '.']
+                      else
+                        ['.', '#']
+                      end
+
       (1...components.count).each do |index|
-        next unless components[index].start_with?('.') &&
-                    components[index - 1].start_with?('#')
+        next unless components[index].start_with?(first) &&
+                    components[index - 1].start_with?(second)
 
         record_lint(node, 'Classes should be listed before IDs '\
                           "(#{components[index]} should precede #{components[index - 1]})")

--- a/spec/haml_lint/linter/classes_before_ids_spec.rb
+++ b/spec/haml_lint/linter/classes_before_ids_spec.rb
@@ -33,16 +33,34 @@ describe HamlLint::Linter::ClassesBeforeIds do
     it { should_not report_lint }
   end
 
-  context 'when tag has classes before IDs' do
-    let(:haml) { '.class1.class2.class3#id1#id2#id3' }
+  context 'when configured with classes first (by default)' do
+    context 'when tag has classes before IDs' do
+      let(:haml) { '.class1.class2.class3#id1#id2#id3' }
 
-    it { should_not report_lint }
+      it { should_not report_lint }
+    end
+
+    context 'when tag has IDs before classes' do
+      let(:haml) { '#id1#id2#id3.class1.class2.class3' }
+
+      it { should report_lint }
+    end
   end
 
-  context 'when tag has IDs before classes' do
-    let(:haml) { '#id1#id2#id3.class1.class2.class3' }
+  context 'when configured with ids first' do
+    let(:config) { super().merge('EnforcedStyle' => 'id') }
 
-    it { should report_lint }
+    context 'when tag has IDs before classes' do
+      let(:haml) { '#id1#id2#id3.class1.class2.class3' }
+
+      it { should_not report_lint }
+    end
+
+    context 'when tag has classes before IDs' do
+      let(:haml) { '.class1.class2.class3#id1#id2#id3' }
+
+      it { should report_lint }
+    end
   end
 
   context 'when tag has a class then ID then class' do


### PR DESCRIPTION
I'm aware that `haml-lint` is an opinionated tool, I'd like to know whether there's a place in the tool for "our opinion by default, but other opinions are available".

If this isn't a direction you want to take then that's absolutely fine, but I'm also happy to work more on the implementation of what a "configurable style" looks like, if this isn't good enough for the project. For example Rubocop allows a `SupportedStyles` parameter to detect invalid style selections.