### PR TITLE
Disable the Metrics/BlockLength cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -64,6 +64,7 @@ linters:
       - Lint/BlockAlignment
       - Lint/EndAlignment
       - Lint/Void
+      - Metrics/BlockLength
       - Metrics/LineLength
       - Style/AlignParameters
       - Style/BlockNesting


### PR DESCRIPTION
This RuboCop check which as introduced in RuboCop 0.44.0 does not make
sense for HAML. Hence, it is now disabled.