### PR TITLE
Fixed ClassesBeforeIds message when IDs first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * Fix `ClassesBeforeIds` output format to handle `id` EnforcedStyle option better
+* Allow report_lint Rspec matcher to test lint message
 
 ## 0.18.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HAML-Lint Changelog
 
+## master (unreleased)
+
+* Fix `ClassesBeforeIds` output format to handle `id` EnforcedStyle option better
+
 ## 0.18.2
 
 * Fix `Checkstyle` output format to handle lints with no associated linter

--- a/lib/haml_lint/linter/classes_before_ids.rb
+++ b/lib/haml_lint/linter/classes_before_ids.rb
@@ -30,13 +30,13 @@ module HamlLint
     private
 
     def attribute_prefix_order
-      default = %w(. #)
+      default = %w[. #]
       default.reverse! if ids_first?
       default
     end
 
     def attribute_type_order
-      default = %w(Classes IDs)
+      default = %w[Classes IDs]
       default.reverse! if ids_first?
       default
     end

--- a/lib/haml_lint/linter/classes_before_ids.rb
+++ b/lib/haml_lint/linter/classes_before_ids.rb
@@ -9,18 +9,20 @@ module HamlLint
       '#' => :id,
     }.freeze
 
+    MSG = '%s should be listed before %s (%s should precede %s)'.freeze
+
     def visit_tag(node)
       # Convert ".class#id" into [.class, #id] (preserving order)
       components = node.static_attributes_source.scan(/[.#][^.#]+/)
 
       first, second = attribute_prefix_order
 
-      (1...components.count).each do |index|
-        next unless components[index].start_with?(first) &&
-                    components[index - 1].start_with?(second)
+      components.each_cons(2) do |current_val, next_val|
+        next unless next_val.start_with?(first) &&
+                    current_val.start_with?(second)
 
-        record_lint(node, 'Classes should be listed before IDs '\
-                          "(#{components[index]} should precede #{components[index - 1]})")
+        failure_message = format(MSG, *(attribute_type_order + [next_val, current_val]))
+        record_lint(node, failure_message)
         break
       end
     end
@@ -28,13 +30,23 @@ module HamlLint
     private
 
     def attribute_prefix_order
-      enforced_style = config.fetch('EnforcedStyle', 'class')
-      case enforced_style
-      when 'id'
-        ['#', '.']
-      else
-        ['.', '#']
-      end
+      default = %w(. #)
+      default.reverse! if ids_first?
+      default
+    end
+
+    def attribute_type_order
+      default = %w(Classes IDs)
+      default.reverse! if ids_first?
+      default
+    end
+
+    def enforced_style
+      config.fetch('EnforcedStyle', 'class')
+    end
+
+    def ids_first?
+      enforced_style == 'id'
     end
   end
 end

--- a/spec/haml_lint/linter/classes_before_ids_spec.rb
+++ b/spec/haml_lint/linter/classes_before_ids_spec.rb
@@ -43,7 +43,11 @@ describe HamlLint::Linter::ClassesBeforeIds do
     context 'when tag has IDs before classes' do
       let(:haml) { '#id1#id2#id3.class1.class2.class3' }
 
-      it { should report_lint message: 'Classes should be listed before IDs (.class1 should precede #id3)' }
+      it do
+        should report_lint(
+          message: 'Classes should be listed before IDs (.class1 should precede #id3)'
+        )
+      end
     end
   end
 
@@ -59,19 +63,31 @@ describe HamlLint::Linter::ClassesBeforeIds do
     context 'when tag has classes before IDs' do
       let(:haml) { '.class1.class2.class3#id1#id2#id3' }
 
-      it { should report_lint message: 'IDs should be listed before Classes (#id1 should precede .class3)' }
+      it do
+        should report_lint(
+          message: 'IDs should be listed before Classes (#id1 should precede .class3)'
+        )
+      end
     end
   end
 
   context 'when tag has a class then ID then class' do
     let(:haml) { '.class1#id.class2' }
 
-    it { should report_lint message: 'Classes should be listed before IDs (.class2 should precede #id)' }
+    it do
+      should report_lint(
+        message: 'Classes should be listed before IDs (.class2 should precede #id)'
+      )
+    end
   end
 
   context 'when tag has an ID then class then ID' do
     let(:haml) { '#id1.class#id2' }
 
-    it { should report_lint message: 'Classes should be listed before IDs (.class should precede #id1)' }
+    it do
+      should report_lint(
+        message: 'Classes should be listed before IDs (.class should precede #id1)'
+      )
+    end
   end
 end

--- a/spec/haml_lint/linter/classes_before_ids_spec.rb
+++ b/spec/haml_lint/linter/classes_before_ids_spec.rb
@@ -43,7 +43,7 @@ describe HamlLint::Linter::ClassesBeforeIds do
     context 'when tag has IDs before classes' do
       let(:haml) { '#id1#id2#id3.class1.class2.class3' }
 
-      it { should report_lint }
+      it { should report_lint message: 'Classes should be listed before IDs (.class1 should precede #id3)' }
     end
   end
 
@@ -59,19 +59,19 @@ describe HamlLint::Linter::ClassesBeforeIds do
     context 'when tag has classes before IDs' do
       let(:haml) { '.class1.class2.class3#id1#id2#id3' }
 
-      it { should report_lint }
+      it { should report_lint message: 'IDs should be listed before Classes (#id1 should precede .class3)' }
     end
   end
 
   context 'when tag has a class then ID then class' do
     let(:haml) { '.class1#id.class2' }
 
-    it { should report_lint }
+    it { should report_lint message: 'Classes should be listed before IDs (.class2 should precede #id)' }
   end
 
   context 'when tag has an ID then class then ID' do
     let(:haml) { '#id1.class#id2' }
 
-    it { should report_lint }
+    it { should report_lint message: 'Classes should be listed before IDs (.class should precede #id1)' }
   end
 end

--- a/spec/support/matchers/report_lint.rb
+++ b/spec/support/matchers/report_lint.rb
@@ -2,19 +2,26 @@ RSpec::Matchers.define :report_lint do |options|
   options ||= {}
   count = options[:count]
   expected_line = options[:line]
+  expected_message = options[:message]
 
   match do |linter|
-    has_lints?(linter, expected_line, count)
+    has_lints?(linter, expected_line, count, expected_message)
   end
 
   failure_message do |linter|
     'expected that a lint would be reported' +
-      (expected_line ? " on line #{expected_line}" : '') +
+      extended_expectations(expected_line, expected_message) +
       case linter.lints.count
       when 0
         ''
       when 1
-        ", but was on line #{linter.lints.first.line}"
+        messages = [', but']
+        messages << "reported message '#{linter.lints.first.message}'" if expected_message
+        if expected_line
+          messages << 'was' unless expected_message
+          messages << "on line #{linter.lints.first.line}"
+        end
+        messages.join ' '
       else
         lines = lint_lines(linter)
         ", but lints were reported on lines #{lines[0...-1].join(', ')} and #{lines.last}"
@@ -26,10 +33,15 @@ RSpec::Matchers.define :report_lint do |options|
   end
 
   description do
-    'report a lint' + (expected_line ? " on line #{expected_line}" : '')
+    'report a lint' + extended_expectations(expected_line, expected_message)
   end
 
-  def has_lints?(linter, expected_line, count)
+  def extended_expectations(expected_line, expected_message)
+    (expected_line ? " on line #{expected_line}" : '') +
+      (expected_message ? " with message '#{expected_message}'" : '')
+  end
+
+  def has_lints?(linter, expected_line, count, expected_message)
     if expected_line && count
       linter.lints.count == count &&
         lint_lines(linter).all? { |line| line == expected_line }
@@ -37,6 +49,8 @@ RSpec::Matchers.define :report_lint do |options|
       lint_lines(linter).include?(expected_line)
     elsif count
       linter.lints.count == count
+    elsif expected_message
+      lint_messages(linter).all? { |message| message == expected_message }
     else
       linter.lints.count > 0
     end
@@ -44,5 +58,9 @@ RSpec::Matchers.define :report_lint do |options|
 
   def lint_lines(linter)
     linter.lints.map(&:line)
+  end
+
+  def lint_messages(linter)
+    linter.lints.map(&:message)
   end
 end

--- a/spec/support/matchers/report_lint.rb
+++ b/spec/support/matchers/report_lint.rb
@@ -42,18 +42,38 @@ RSpec::Matchers.define :report_lint do |options|
   end
 
   def has_lints?(linter, expected_line, count, expected_message)
-    if expected_line && count
-      linter.lints.count == count &&
-        lint_lines(linter).all? { |line| line == expected_line }
-    elsif expected_line
-      lint_lines(linter).include?(expected_line)
+    if expected_line
+      has_expected_line_lints?(linter, expected_line, count, expected_message)
     elsif count
       linter.lints.count == count
     elsif expected_message
-      lint_messages(linter).all? { |message| message == expected_message }
+      lint_messages_match?(linter, expected_message)
     else
-      linter.lints.count > 0
+      linter.lints.any?
     end
+  end
+
+  def has_expected_line_lints?(linter, expected_line, count, expected_message)
+    if count
+      multiple_lints_match_line?(linter, expected_line, count)
+    elsif expected_message
+      lint_on_line_matches_message?(linter, expected_line, expected_message)
+    else
+      lint_lines(linter).include?(expected_line)
+    end
+  end
+
+  def multiple_lints_match_line?(linter, expected_line, count)
+    linter.lints.count == count &&
+      lint_lines(linter).all? { |line| line == expected_line }
+  end
+
+  def lint_on_line_matches_message?(linter, expected_line, expected_message)
+    linter.lints.any? { |lint| lint.line == expected_line && lint.message == expected_message }
+  end
+
+  def lint_messages_match?(linter, expected_message)
+    lint_messages(linter).all? { |message| message == expected_message }
   end
 
   def lint_lines(linter)


### PR DESCRIPTION
## Description of problem
#### ClassesBeforeIds linter

When EnforcedStyle is IDs first, linter still reports Classes first (albeit with the failing attributes around the correct way. This change fixes that by making the message dynamic and reporting the message based on the EnforcedStyle
#### report_lint rspec matcher

To test that the above change 'worked', I also added a change to the report_lint matcher so it will fail if the lint messages don't match the expectation.

N.B. Because the matcher was getting a bit heavy, I opted to only check the message if the expected line and count were correct. This also simplified the failure message somewhat. 

I couldn't see any specs for the report_lint matcher, but I have tested a bunch of combinations of failures/messages/lines etc and it appears to work ok. Feels like this could be a change in its own right but the change to the ClassesBeforeIds change doesn't really make sense unless these matcher changes come along for the ride.
