### PR TITLE
Save temporary rubocop file as binary, closes #167

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -69,6 +69,7 @@ linters:
       - Style/AlignParameters
       - Style/BlockNesting
       - Style/ElseAlignment
+      - Style/EndOfLine
       - Style/FileName
       - Style/FinalNewline
       - Style/FrozenStringLiteralComment

--- a/spec/haml_lint/linter/rubocop_spec.rb
+++ b/spec/haml_lint/linter/rubocop_spec.rb
@@ -60,4 +60,10 @@ describe HamlLint::Linter::RuboCop do
         .to have_received(:run).with(array_including('--config', 'some-rubocop.yml'))
     end
   end
+
+  context 'when running inspecting a file containing CRLF line endings (#GH-167)' do
+    let(:haml) { "- if signed_in?(viewer)\r\n%span Stuff" }
+
+    it { should_not report_lint }
+  end
 end


### PR DESCRIPTION
See #167 

Not exactly using line endings from the HAML (this would be the perfect solution). But at least we won't have to disable Style/EndOfLine to get rid of the false positives where rubocop reports CRLF offenses while the HAML source only contains LFs.