### PR TITLE
Allow templating syntax as static class

### DIFF
--- a/lib/haml_lint/linter/class_attribute_with_static_value.rb
+++ b/lib/haml_lint/linter/class_attribute_with_static_value.rb
@@ -9,10 +9,16 @@ module HamlLint
   # ...over:
   #
   #   %tag{ class: 'class-name' }
+  #
+  # But will allow invalid class names for templating:
+  #
+  #   %tag{ class: '{{ template-var }}' }
   class Linter::ClassAttributeWithStaticValue < Linter
     include LinterRegistry
 
     STATIC_TYPES = [:str, :sym].freeze
+
+    VALID_CLASS_REGEX = /^-?[_a-zA-Z]+[_a-zA-Z0-9-]*$/
 
     def visit_tag(node)
       return unless contains_class_attribute?(node.dynamic_attributes_sources)
@@ -41,7 +47,8 @@ module HamlLint
 
       STATIC_TYPES.include?(key.type) &&
         key.children.first.to_sym == :class &&
-        STATIC_TYPES.include?(value.type)
+        STATIC_TYPES.include?(value.type) &&
+        value.children.first =~ VALID_CLASS_REGEX
     end
   end
 end

--- a/spec/haml_lint/linter/class_attribute_with_static_value_spec.rb
+++ b/spec/haml_lint/linter/class_attribute_with_static_value_spec.rb
@@ -62,4 +62,10 @@ describe HamlLint::Linter::ClassAttributeWithStaticValue do
 
     it { should_not report_lint }
   end
+
+  context 'when tag attributes contain invalid value' do
+    let(:haml) { "%th{ class: '{{value}}' }" }
+
+    it { should_not report_lint }
+  end
 end


### PR DESCRIPTION
There are many cases where a templating language's syntax is used in haml classes.

For example, moustache templating...

```haml
.some-class{ class: '{{ rendered_dynamic_variable }}' }
```

This currently fails the `ClassAttributeWithStaticValue` linter.

I believe these should be accounted for in the `ClassAttributeWithStaticValue` linter. The linter should ignore any class names that are not valid css syntax.