### PR TITLE
Report syntax errors as a "Syntax" linter

### DIFF
--- a/lib/haml_lint/linter/syntax.rb
+++ b/lib/haml_lint/linter/syntax.rb
@@ -1,0 +1,6 @@
+module HamlLint
+  # A catch-all linter for syntax violations raised by the Haml parser.
+  class Linter::Syntax < Linter
+    include LinterRegistry
+  end
+end

--- a/lib/haml_lint/runner.rb
+++ b/lib/haml_lint/runner.rb
@@ -51,7 +51,8 @@ module HamlLint
       begin
         document = HamlLint::Document.new(File.read(file), file: file, config: config)
       rescue HamlLint::Exceptions::ParseError => ex
-        return [HamlLint::Lint.new(nil, file, ex.line, ex.to_s, :error)]
+        return [HamlLint::Lint.new(HamlLint::Linter::Syntax.new(config), file,
+                                   ex.line, ex.to_s, :error)]
       end
 
       linter_selector.linters_for_file(file).map do |linter|

--- a/spec/haml_lint/runner_spec.rb
+++ b/spec/haml_lint/runner_spec.rb
@@ -60,5 +60,31 @@ describe HamlLint::Runner do
         subject
       end
     end
+
+    context 'when there is a Haml parsing error in a file' do
+      let(:files) { %w[inconsistent_indentation.haml] }
+
+      include_context 'isolated environment'
+
+      before do
+        # The runner needs to actually look for files to lint
+        runner.should_receive(:collect_lints).and_call_original
+
+        `echo "%div\n  %span Hello, world\n\t%span Goodnight, moon" > inconsistent_indentation.haml`
+      end
+
+      it 'adds a syntax lint to the output' do
+        subject.lints.size.should == 1
+
+        lint = subject.lints.first
+        lint.line.should == 2
+        lint.filename.should == 'inconsistent_indentation.haml'
+        lint.message.should match(/^Inconsistent indentation/)
+        lint.severity.should == :error
+
+        linter = lint.linter
+        linter.name.should == 'Syntax'
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently, syntax errors are reported without a linter. This is
inconsistent with the way the rest of the lint is reported, so it makes
sense to wrap syntax errors in a similar construct as the rest of the
lint.

Since syntax errors are detected via a `Haml::Parser` that bubbles up an
exception to the `Runner`, the only place to currently put the logic is
within the `Runner` itself. This makes the `HamlLint::Linter::Syntax`
class look funny because it doesn't lint on a Haml AST - it lints on the
absence of an AST.

The benefit of this for me is that it will allow me to report syntax error
lints in my Code Climate engine, as opposed to ignoring them due to
the lack of a linter name.