### PR TITLE
Add a linter for checking id name formats

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -37,6 +37,10 @@ linters:
   HtmlAttributes:
     enabled: true
 
+  IdNames:
+    enabled: true
+    style: lisp_case
+
   ImplicitDiv:
     enabled: true
 

--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -11,6 +11,7 @@ Below is a list of linters supported by `haml-lint`, ordered alphabetically.
 * [EmptyScript](#emptyscript)
 * [FinalNewline](#finalnewline)
 * [HtmlAttributes](#htmlattributes)
+* [IdNames](#idnames)
 * [ImplicitDiv](#implicitdiv)
 * [Indentation](#indentation)
 * [LeadingCommentSpace](#leadingcommentspace)
@@ -214,6 +215,41 @@ complexity to your templates as there are now two different ways to define
 attributes. Standardizing on when to use HTML-style versus hash-style adds
 greater cognitive load when writing templates. Using one style makes this
 easier.
+
+## IdNames
+
+Check the naming conventions of id attributes against one of two possible
+preferred styles, `lisp_case` (default), `camel_case`, `pascal_case`, or
+`snake_case`:
+
+**Bad: inconsistent id names**
+```haml
+#lisp-case
+#camelCase
+#PascalCase
+#snake_case
+```
+
+**With default `lisp_case` style option: require ids in lisp-case-format**
+```haml
+#lisp-case
+```
+
+**With `camel_case` style option: require ids in camelCaseFormat**
+```haml
+#camelCase
+```
+
+**With `pascal_case` style option: require ids in PascalCaseFormat**
+```haml
+#PascalCase
+```
+
+**With `snake_case` style option: require ids in snake_case_format*
+```haml
+#snake_case
+%div{ id: 'snake_case' }
+```
 
 ## ImplicitDiv
 

--- a/lib/haml_lint/linter/id_names.rb
+++ b/lib/haml_lint/linter/id_names.rb
@@ -1,0 +1,28 @@
+module HamlLint
+  # Checks for `id` attributes in specific cases on tags.
+  class Linter::IdNames < Linter
+    include LinterRegistry
+
+    STYLIZED_NAMES = {
+      'camel_case' => 'camelCase',
+      'lisp_case' => 'lisp-case',
+      'pascal_case' => 'PascalCase',
+      'snake_case' => 'snake_case',
+    }.freeze
+
+    STYLES = {
+      'camel_case' => /\A[a-z][\da-zA-Z]+\z/,
+      'lisp_case' => /\A[\da-z-]+\z/,
+      'pascal_case' => /\A[A-Z][\da-zA-Z]+\z/,
+      'snake_case' => /\A[\da-z_]+\z/,
+    }.freeze
+
+    def visit_tag(node)
+      return unless (id = node.tag_id)
+
+      style = config['style'] || 'lisp_case'
+      matcher = STYLES[style]
+      record_lint(node, "`id` attribute must be in #{STYLIZED_NAMES[style]}") unless id =~ matcher
+    end
+  end
+end

--- a/lib/haml_lint/tree/tag_node.rb
+++ b/lib/haml_lint/tree/tag_node.rb
@@ -148,6 +148,13 @@ module HamlLint::Tree
       dynamic_attributes_source[:html][/\A\((.*)\)\z/, 1] if html_attributes?
     end
 
+    # ID of the HTML tag.
+    #
+    # @return [String]
+    def tag_id
+      @value[:attributes]['id']
+    end
+
     # Name of the HTML tag.
     #
     # @return [String]

--- a/spec/haml_lint/linter/id_names_spec.rb
+++ b/spec/haml_lint/linter/id_names_spec.rb
@@ -1,0 +1,161 @@
+require 'spec_helper'
+
+RSpec.describe HamlLint::Linter::IdNames do
+  include_context 'linter'
+
+  context 'when there is no id' do
+    let(:haml) { '%div' }
+
+    context 'default config (lisp_case)' do
+      it { should_not report_lint }
+    end
+
+    context 'with camel_case config' do
+      let(:config) { super().merge('style' => 'camel_case') }
+
+      it { should_not report_lint }
+    end
+
+    context 'with pascal_case config' do
+      let(:config) { super().merge('style' => 'pascal_case') }
+
+      it { should_not report_lint }
+    end
+
+    context 'with snake_case config' do
+      let(:config) { super().merge('style' => 'snake_case') }
+
+      it { should_not report_lint }
+    end
+  end
+
+  context 'when there is a one-word, lowercase id' do
+    let(:haml) { '#name' }
+
+    context 'default config (lisp_case)' do
+      it { should_not report_lint }
+    end
+
+    context 'with camel_case config' do
+      let(:config) { super().merge('style' => 'camel_case') }
+
+      it { should_not report_lint }
+    end
+
+    context 'with pascal_case config' do
+      let(:config) { super().merge('style' => 'pascal_case') }
+
+      it { should report_lint line: 1, message: '`id` attribute must be in PascalCase' }
+    end
+
+    context 'with snake_case config' do
+      let(:config) { super().merge('style' => 'snake_case') }
+
+      it { should_not report_lint }
+    end
+  end
+
+  context 'when there is a Lisp case id' do
+    let(:haml) { '#lisp-case' }
+
+    context 'default config (lisp_case)' do
+      it { should_not report_lint }
+    end
+
+    context 'with camel_case config' do
+      let(:config) { super().merge('style' => 'camel_case') }
+
+      it { should report_lint line: 1, message: '`id` attribute must be in camelCase' }
+    end
+
+    context 'with pascal_case config' do
+      let(:config) { super().merge('style' => 'pascal_case') }
+
+      it { should report_lint line: 1, message: '`id` attribute must be in PascalCase' }
+    end
+
+    context 'with snake_case config' do
+      let(:config) { super().merge('style' => 'snake_case') }
+
+      it { should report_lint line: 1, message: '`id` attribute must be in snake_case' }
+    end
+  end
+
+  context 'when there is a camel case id' do
+    let(:haml) { '#camelCase' }
+
+    context 'default config (lisp_case)' do
+      it { should report_lint line: 1, message: '`id` attribute must be in lisp-case' }
+    end
+
+    context 'with camel_case config' do
+      let(:config) { super().merge('style' => 'camel_case') }
+
+      it { should_not report_lint }
+    end
+
+    context 'with pascal_case config' do
+      let(:config) { super().merge('style' => 'pascal_case') }
+
+      it { should report_lint line: 1, message: '`id` attribute must be in PascalCase' }
+    end
+
+    context 'with snake_case config' do
+      let(:config) { super().merge('style' => 'snake_case') }
+
+      it { should report_lint line: 1, message: '`id` attribute must be in snake_case' }
+    end
+  end
+
+  context 'when there is a Pascal case id' do
+    let(:haml) { '#PascalCase' }
+
+    context 'default config (lisp_case)' do
+      it { should report_lint line: 1, message: '`id` attribute must be in lisp-case' }
+    end
+
+    context 'with camel_case config' do
+      let(:config) { super().merge('style' => 'camel_case') }
+
+      it { should report_lint line: 1, message: '`id` attribute must be in camelCase' }
+    end
+
+    context 'with pascal_case config' do
+      let(:config) { super().merge('style' => 'pascal_case') }
+
+      it { should_not report_lint }
+    end
+
+    context 'with snake_case config' do
+      let(:config) { super().merge('style' => 'snake_case') }
+
+      it { should report_lint line: 1, message: '`id` attribute must be in snake_case' }
+    end
+  end
+
+  context 'when there is a snake case id' do
+    let(:haml) { '#snake_case' }
+
+    context 'default config (lisp_case)' do
+      it { should report_lint line: 1, message: '`id` attribute must be in lisp-case' }
+    end
+
+    context 'with camel_case config' do
+      let(:config) { super().merge('style' => 'camel_case') }
+
+      it { should report_lint line: 1, message: '`id` attribute must be in camelCase' }
+    end
+
+    context 'with pascal_case config' do
+      let(:config) { super().merge('style' => 'pascal_case') }
+
+      it { should report_lint line: 1, message: '`id` attribute must be in PascalCase' }
+    end
+
+    context 'with snake_case config' do
+      let(:config) { super().merge('style' => 'snake_case') }
+
+      it { should_not report_lint }
+    end
+  end
+end


### PR DESCRIPTION
Haml style should be consistent in the naming of things. In particular,
we should be consistent in the format that our tag ids have. This linter
lets you customize the format of your ids to one of four formats:

* `lisp-case` like the Bootstrap convention (default)
* `camelCase` like the JavaScript variable convention
* `PascalCase` like the Ruby class name or React component convention
* `snake_case` like the Ruby variable convention

This is configured in the `haml-lint.yml` file as follows:

```yaml
linters:
  IdNames:
    enabled: true
    style: <STYLE>
```

where `<STYLE>` is one of: `lisp_case`, `camel_case`, `pascal_case`, or
`snake_case`.

Closes #138