### PR TITLE
Print summary of lints and files inspected

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Command Line Flag         | Description
 `-x`/`--exclude-linter`   | Specify which linters you _don't_ want to run
 `-r`/`--reporter`         | Specify which reporter you want to use to generate the output
 `--[no-]color`            | Whether to output in color
+`--[no-]summary`          | Whether to output a summary in the default reporter
 `--show-linters`          | Show all registered linters
 `--show-reporters`        | Display available reporters
 `-h`/`--help`             | Show command line flag documentation

--- a/lib/haml_lint/cli.rb
+++ b/lib/haml_lint/cli.rb
@@ -33,7 +33,7 @@ module HamlLint
     #
     # @return [Integer] exit status code
     def act_on_options(options)
-      log.color_enabled = options.fetch(:color, log.tty?)
+      configure_logger(options)
 
       if options[:help]
         print_help(options)
@@ -50,6 +50,14 @@ module HamlLint
       else
         scan_for_lints(options)
       end
+    end
+
+    # Given the provided options, configure the logger.
+    #
+    # @return [void]
+    def configure_logger(options)
+      log.color_enabled = options.fetch(:color, log.tty?)
+      log.summary_enabled = options.fetch(:summary, true)
     end
 
     # Outputs a message and returns an appropriate error code for the specified

--- a/lib/haml_lint/logger.rb
+++ b/lib/haml_lint/logger.rb
@@ -5,6 +5,10 @@ module HamlLint
     # @return [true,false]
     attr_accessor :color_enabled
 
+    # Whether to output a summary in the log for certain reporters.
+    # @return [true,false]
+    attr_accessor :summary_enabled
+
     # Creates a logger which outputs nothing.
     # @return [HamlLint::Logger]
     def self.silent
@@ -14,8 +18,10 @@ module HamlLint
     # Creates a new {HamlLint::Logger} instance.
     #
     # @param out [IO] the output destination.
-    def initialize(out)
+    # @param summary [true,false] whether to print summaries
+    def initialize(out, summary: true)
       @out = out
+      @summary_enabled = summary
     end
 
     # Print the specified output.

--- a/lib/haml_lint/options.rb
+++ b/lib/haml_lint/options.rb
@@ -15,6 +15,7 @@ module HamlLint
 
         add_linter_options parser
         add_file_options parser
+        add_logger_options parser
         add_info_options parser
       end.parse!(args)
 
@@ -80,10 +81,6 @@ module HamlLint
         @options[:show_reporters] = true
       end
 
-      parser.on('--[no-]color', 'Force output to be colorized') do |color|
-        @options[:color] = color
-      end
-
       parser.on_tail('-h', '--help', 'Display help documentation') do
         @options[:help] = parser.help
       end
@@ -94,6 +91,16 @@ module HamlLint
 
       parser.on_tail('-V', '--verbose-version', 'Display verbose version information') do
         @options[:verbose_version] = true
+      end
+    end
+
+    def add_logger_options(parser)
+      parser.on('--[no-]color', 'Force output to be colorized') do |color|
+        @options[:color] = color
+      end
+
+      parser.on('--[no-]summary', 'Print a summary of your linting report') do |summary|
+        @options[:summary] = summary
       end
     end
   end

--- a/lib/haml_lint/reporter/default_reporter.rb
+++ b/lib/haml_lint/reporter/default_reporter.rb
@@ -10,9 +10,19 @@ module HamlLint
         print_type(lint)
         print_message(lint)
       end
+
+      print_summary(report)
     end
 
     private
+
+    def pluralize(word, count: 1)
+      if count.zero? || count > 1
+        "#{count} #{word}s"
+      else
+        "#{count} #{word}"
+      end
+    end
 
     def print_location(lint)
       log.info lint.filename, false
@@ -34,6 +44,30 @@ module HamlLint
       end
 
       log.log lint.message
+    end
+
+    def print_summary(report)
+      return unless log.summary_enabled
+
+      print_summary_files(report)
+      print_summary_lints(report)
+
+      log.log ' detected'
+    end
+
+    def print_summary_files(report)
+      log.log "\n#{pluralize('file', count: report.files.count)} inspected, ", false
+    end
+
+    def print_summary_lints(report)
+      lint_count = report.lints.size
+      lint_message = pluralize('lint', count: lint_count)
+
+      if lint_count == 0
+        log.log lint_message, false
+      else
+        log.error lint_message, false
+      end
     end
   end
 end

--- a/spec/haml_lint/options_spec.rb
+++ b/spec/haml_lint/options_spec.rb
@@ -107,6 +107,24 @@ describe HamlLint::Options do
       end
     end
 
+    context 'summary' do
+      describe 'manually on' do
+        let(:args) { ['--summary'] }
+
+        it 'sets the `summary` option to true' do
+          subject.should include summary: true
+        end
+      end
+
+      describe 'manually off' do
+        let(:args) { ['--no-summary'] }
+
+        it 'sets the `summary option to false' do
+          subject.should include summary: false
+        end
+      end
+    end
+
     context 'with a list of file glob patterns' do
       let(:args) { %w[app/**/*.haml some-dir/some-template.haml] }
 


### PR DESCRIPTION
Seeing a total number of lints across all the inspected files, along
with the number of files inspected, can be helpful when you're
onboarding Haml-Lint onto a project. Since you'll likely have many
violations when starting out, seeing the total number of lints go down
over time will help motivate you to keep going.

Closes #123