### PR TITLE
Remove extra entry in Gemfile from Haml 5 change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'haml', '~> 5.0.0.beta.2', git: 'https://github.com/haml/haml'
 gem 'rspec', '~> 3.0'
 gem 'rspec-its', '~> 1.0'
 


### PR DESCRIPTION
I accidentally committed this and it got pulled in. The Haml dependency
should be specified in the appraisal, not in the base Gemfile.