### PR TITLE
Add --fail-level option for the CLI and Rake task

### DIFF
--- a/lib/haml_lint.rb
+++ b/lib/haml_lint.rb
@@ -19,6 +19,7 @@ require 'haml_lint/file_finder'
 require 'haml_lint/runner'
 require 'haml_lint/utils'
 require 'haml_lint/version'
+require 'haml_lint/severity'
 
 # Load all parse tree node classes
 require 'haml_lint/tree/node'

--- a/lib/haml_lint/exceptions.rb
+++ b/lib/haml_lint/exceptions.rb
@@ -18,4 +18,7 @@ module HamlLint::Exceptions
 
   # Raised when an unsupported Haml version is detected
   class UnknownHamlVersion < StandardError; end
+
+  # Raised when a severity is not recognized
+  class UnknownSeverity < StandardError; end
 end

--- a/lib/haml_lint/lint.rb
+++ b/lib/haml_lint/lint.rb
@@ -28,14 +28,14 @@ module HamlLint
       @filename = filename
       @line     = line || 0
       @message  = message
-      @severity = severity
+      @severity = Severity.new(severity)
     end
 
     # Return whether this lint has a severity of error.
     #
     # @return [Boolean]
     def error?
-      @severity == :error
+      @severity.error?
     end
   end
 end

--- a/lib/haml_lint/options.rb
+++ b/lib/haml_lint/options.rb
@@ -48,7 +48,7 @@ module HamlLint
 
       parser.on('--fail-level fail_level', String,
                 'Specify which level you want the suite to fail') do |fail_level|
-        @options[:fail_level] = fail_level.to_sym
+        @options[:fail_level] = HamlLint::Severity.new(fail_level.to_sym)
       end
     end
 

--- a/lib/haml_lint/options.rb
+++ b/lib/haml_lint/options.rb
@@ -45,6 +45,11 @@ module HamlLint
                 'Specify which reporter you want to use to generate the output') do |reporter|
         @options[:reporter] = load_reporter_class(reporter.capitalize)
       end
+
+      parser.on('--fail-level fail_level', String,
+                'Specify which level you want the suite to fail') do |fail_level|
+        @options[:fail_level] = fail_level.to_sym
+      end
     end
 
     # Returns the class of the specified Reporter.

--- a/lib/haml_lint/rake_task.rb
+++ b/lib/haml_lint/rake_task.rb
@@ -51,9 +51,14 @@ module HamlLint
     # @return [true,false]
     attr_accessor :quiet
 
-    # Whether output from haml-lint should not be displayed to the standard out
-    # stream.
-    # @return [true,false]
+    # The severity level above which we should fail the Rake task.
+    #
+    # @example
+    #   HamlLint::RakeTask.new do |task|
+    #     task.fail_level = 'error'
+    #   end
+    #
+    # @return [String]
     attr_accessor :fail_level
 
     # Create the task so it exists in the current namespace.

--- a/lib/haml_lint/rake_task.rb
+++ b/lib/haml_lint/rake_task.rb
@@ -51,6 +51,11 @@ module HamlLint
     # @return [true,false]
     attr_accessor :quiet
 
+    # Whether output from haml-lint should not be displayed to the standard out
+    # stream.
+    # @return [true,false]
+    attr_accessor :fail_level
+
     # Create the task so it exists in the current namespace.
     #
     # @param name [Symbol] task name
@@ -82,8 +87,7 @@ module HamlLint
     #
     # @param task_args [Rake::TaskArguments]
     def run_cli(task_args)
-      cli_args = ['--config', config] if config
-
+      cli_args = parse_args
       logger = quiet ? HamlLint::Logger.silent : HamlLint::Logger.new(STDOUT)
       result = HamlLint::CLI.new(logger).run(Array(cli_args) + files_to_lint(task_args))
 
@@ -117,6 +121,11 @@ module HamlLint
       description += " #{files.join(' ')}" if files.any?
       description += ' [files...]`'
       description
+    end
+
+    def parse_args
+      cli_args = config ? ['--config', config] : []
+      cli_args.concat(['--fail-level', fail_level]) if fail_level
     end
   end
 end

--- a/lib/haml_lint/report.rb
+++ b/lib/haml_lint/report.rb
@@ -19,7 +19,7 @@ module HamlLint
     end
 
     def failed?
-      return @lints.any unless @fail_level
+      return @lints.any? unless @fail_level
 
       @lints.find { |lint| lint.severity.level >= @fail_level.level }
     end

--- a/lib/haml_lint/report.rb
+++ b/lib/haml_lint/report.rb
@@ -3,6 +3,7 @@ module HamlLint
   class Report
     # List of lints that were found.
     attr_accessor :lints
+    attr_accessor :fail_level
 
     # List of files that were linted.
     attr_reader :files
@@ -11,13 +12,16 @@ module HamlLint
     #
     # @param lints [Array<HamlLint::Lint>] lints that were found
     # @param files [Array<String>] files that were linted
-    def initialize(lints, files)
+    def initialize(lints, files, fail_level = nil)
       @lints = lints.sort_by { |l| [l.filename, l.line] }
       @files = files
+      @fail_level = Severity.new(fail_level) if fail_level
     end
 
     def failed?
-      @lints.any?
+      return @lints.any unless @fail_level
+
+      @lints.find { |lint| lint.severity.level >= @fail_level.level }
     end
   end
 end

--- a/lib/haml_lint/report.rb
+++ b/lib/haml_lint/report.rb
@@ -3,7 +3,9 @@ module HamlLint
   class Report
     # List of lints that were found.
     attr_accessor :lints
-    attr_accessor :fail_level
+
+    # The level of lint to fail after detecting
+    attr_reader :fail_level
 
     # List of files that were linted.
     attr_reader :files
@@ -12,16 +14,18 @@ module HamlLint
     #
     # @param lints [Array<HamlLint::Lint>] lints that were found
     # @param files [Array<String>] files that were linted
-    def initialize(lints, files, fail_level = nil)
+    # @param fail_level [Symbol] the severity level to fail on
+    def initialize(lints, files, fail_level = :warning)
       @lints = lints.sort_by { |l| [l.filename, l.line] }
       @files = files
-      @fail_level = Severity.new(fail_level) if fail_level
+      @fail_level = Severity.new(fail_level)
     end
 
+    # Checks whether any lints were over the fail level
+    #
+    # @return [Boolean]
     def failed?
-      return @lints.any? unless @fail_level
-
-      @lints.find { |lint| lint.severity.level >= @fail_level.level }
+      @lints.any? { |lint| lint.severity >= fail_level }
     end
   end
 end

--- a/lib/haml_lint/runner.rb
+++ b/lib/haml_lint/runner.rb
@@ -10,6 +10,7 @@ module HamlLint
     # @option options :excluded_files [Array<String>]
     # @option options :included_linters [Array<String>]
     # @option options :excluded_linters [Array<String>]
+    # @option options :fail_level
     # @return [HamlLint::Report] a summary of all lints found
     def run(options = {})
       config = load_applicable_config(options)
@@ -21,7 +22,7 @@ module HamlLint
         collect_lints(file, linter_selector, config)
       end.flatten
 
-      HamlLint::Report.new(lints, files)
+      HamlLint::Report.new(lints, files, options[:fail_level])
     end
 
     private

--- a/lib/haml_lint/severity.rb
+++ b/lib/haml_lint/severity.rb
@@ -1,0 +1,46 @@
+module HamlLint
+  # Defines the severity class
+  class Severity
+    include Comparable
+
+    SEVERITY_WARNING = :warning
+    SEVERITY_ERROR = :error
+
+    NAMES = [SEVERITY_WARNING, SEVERITY_ERROR].freeze
+
+    attr_reader :name
+
+    # @api private
+    def initialize(name)
+      fail ArgumentError, "Unknown severity: #{name}" unless NAMES.include?(name)
+
+      @name = name.freeze
+      freeze
+    end
+
+    def level
+      NAMES.index(@name) + 1
+    end
+
+    # @api private
+    def to_s
+      @name.to_s
+    end
+
+    # @api private
+    def ==(other)
+      return @name == other if other.is_a?(Symbol)
+
+      @name == other.name
+    end
+
+    # @api private
+    def <=>(other)
+      level <=> other.level
+    end
+
+    def error?
+      @name == SEVERITY_ERROR
+    end
+  end
+end

--- a/spec/haml_lint/options_spec.rb
+++ b/spec/haml_lint/options_spec.rb
@@ -65,6 +65,22 @@ describe HamlLint::Options do
       end
     end
 
+    context 'with a fail level option' do
+      let(:args) { %w[--fail-level error] }
+
+      it 'sets the `fail_level` option' do
+        subject[:fail_level].should == :error
+      end
+
+      context 'for an unknown fail level' do
+        let(:args) { %w[--fail-level wazoo] }
+
+        it 'raise an error' do
+          expect { subject }.to raise_error HamlLint::Exceptions::UnknownSeverity
+        end
+      end
+    end
+
     context 'with the help option' do
       let(:args) { ['--help'] }
 

--- a/spec/haml_lint/rake_task_spec.rb
+++ b/spec/haml_lint/rake_task_spec.rb
@@ -5,6 +5,7 @@ require 'tempfile'
 describe HamlLint::RakeTask do
   before(:all) do
     HamlLint::RakeTask.new do |t|
+      t.fail_level = 'warning'
       t.quiet = true
     end
   end

--- a/spec/haml_lint/report_spec.rb
+++ b/spec/haml_lint/report_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+RSpec.describe HamlLint::Report do
+  let(:fail_level) { :warning }
+  let(:filenames) { ['some-filename.haml'] }
+  let(:lints) { [] }
+
+  subject(:report) { described_class.new(lints, filenames, fail_level) }
+
+  describe '#failed?' do
+    subject { report.failed? }
+
+    context 'with no lints' do
+      describe '#failed?' do
+        subject { report.failed? }
+
+        it { should == false }
+      end
+    end
+
+    context 'with only warning lints' do
+      let(:lines)        { [502] }
+      let(:descriptions) { ['Description of lint 1'] }
+      let(:severities)   { [:warning] * 2 }
+      let(:linter)       { double(name: 'SomeLinter') }
+
+      let(:lints) do
+        lines.each_with_index.map do |line, index|
+          HamlLint::Lint.new(linter, filenames[index], line, descriptions[index], severities[index])
+        end
+      end
+
+      context 'when fail level is :error' do
+        let(:fail_level) { :error }
+
+        it { should == false }
+      end
+
+      context 'when fail level is :warning' do
+        let(:fail_level) { :warning }
+
+        it { should == true }
+      end
+    end
+
+    context 'with only error lints' do
+      let(:lines)        { [502] }
+      let(:descriptions) { ['Description of lint 1'] }
+      let(:severities)   { [:error] * 2 }
+      let(:linter)       { double(name: 'SomeLinter') }
+
+      let(:lints) do
+        lines.each_with_index.map do |line, index|
+          HamlLint::Lint.new(linter, filenames[index], line, descriptions[index], severities[index])
+        end
+      end
+
+      context 'when fail level is :error' do
+        let(:fail_level) { :error }
+
+        it { should == true }
+      end
+
+      context 'when fail level is :warning' do
+        let(:fail_level) { :warning }
+
+        it { should == true }
+      end
+    end
+  end
+end

--- a/spec/haml_lint/severity_spec.rb
+++ b/spec/haml_lint/severity_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.describe HamlLint::Severity do
+  let(:name) { nil }
+
+  subject(:severity) { described_class.new(name) }
+
+  it 'defaults to a warning' do
+    subject.should == described_class.new(:warning)
+  end
+
+  it 'can be matched against a symbol severity' do
+    subject.should == :warning
+  end
+
+  it 'ranks severities properly' do
+    subject.should < described_class.new(:error)
+  end
+
+  it 'can wrap itself' do
+    subject.should == described_class.new(subject)
+  end
+
+  describe '#error?' do
+    subject { severity.error? }
+
+    it { should == false }
+
+    context 'for an error' do
+      let(:name) { :error }
+
+      it { should == true }
+    end
+  end
+
+  describe '#warning?' do
+    subject { severity.warning? }
+
+    it { should == true }
+
+    context 'for an error' do
+      let(:name) { :error }
+
+      it { should == false }
+    end
+  end
+end


### PR DESCRIPTION
This builds on the work started by @mauu-alpha in June of last year by fleshing out the functionality, extending the domain model of a severity a bit, and adding tests.

By enabling users to only fail on violations that are of the "error" severity, we can make it so you can use Haml-Lint in CI to print out style violations that are of lesser importance, but still let the build pass.

Closes #137 
Closes #142