### PR TITLE
Add a linter to catch alignment tabs

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -9,6 +9,8 @@ PreCommit:
 
   HardTabs:
     enabled: true
+    exclude:
+      - 'lib/haml_lint/linter/README.md'
 
   RuboCop:
     enabled: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -8,6 +8,9 @@
 skip_frontmatter: false
 
 linters:
+  AlignmentTabs:
+    enabled: true
+
   AltText:
     enabled: false
 

--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -2,6 +2,7 @@
 
 Below is a list of linters supported by `haml-lint`, ordered alphabetically.
 
+* [AlignmentTabs](#alignmenttabs)
 * [AltText](#alttext)
 * [ClassAttributeWithStaticValue](#classattributewithstaticvalue)
 * [ClassesBeforeIds](#classesbeforeids)
@@ -27,6 +28,31 @@ Below is a list of linters supported by `haml-lint`, ordered alphabetically.
 * [TrailingWhitespace](#trailingwhitespace)
 * [UnnecessaryInterpolation](#unnecessaryinterpolation)
 * [UnnecessaryStringOutput](#unnecessarystringoutput)
+
+## AlignmentTabs
+
+Don't use tabs for alignment within a tag.
+
+**Bad**
+```haml
+%div
+  %p		Hello, world
+  %span	This is visually aligned with its sibling's content using tabs
+```
+
+**Acceptable, though not recommended**
+```haml
+%div
+  %p    Hello, world
+  %span This is visually aligned with its sibling's content using spaces
+```
+
+**Good**
+```haml
+%div
+  %p Hello, world
+  %span This does not worry about alignment of tag text
+```
 
 ## AltText
 

--- a/lib/haml_lint/linter/alignment_tabs.rb
+++ b/lib/haml_lint/linter/alignment_tabs.rb
@@ -1,0 +1,12 @@
+module HamlLint
+  # Checks for tabs that are placed for alignment of tag content
+  class Linter::AlignmentTabs < Linter
+    REGEX = /[^\s*]\t+/
+
+    def visit_tag(node)
+      if REGEX.match(node.source_code)
+        record_lint(node, 'Avoid using tabs for alignment')
+      end
+    end
+  end
+end

--- a/spec/haml_lint/linter/alignment_tabs_spec.rb
+++ b/spec/haml_lint/linter/alignment_tabs_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe HamlLint::Linter::AlignmentTabs do
+  include_context 'linter'
+
+  context 'when there are no non-indentation tabs' do
+    let(:haml) { '%p Hello' }
+
+    it { should_not report_lint }
+
+    context 'even in a multiline tag that uses tabs for indentation' do
+      let(:haml) { "%p\n\t%span Hello\n\t%span world" }
+
+      it { should_not report_lint }
+    end
+  end
+
+  context 'when there are non-indentation tabs' do
+    let(:haml) { "%p\tHello" }
+
+    it { should report_lint }
+
+    context 'in a multiline tag that uses tabs for indentation' do
+      let(:haml) { "%p\n\t%span Hello\n\t%span\tworld" }
+
+      it { should report_lint line: 3 }
+    end
+  end
+end


### PR DESCRIPTION
Even when using tabs for indentation, it is generally accepted that
using tabs for alignment is something that should be avoided. Because
you can style your tabs to look differently in your editor, there is no
guarantee that your alignment tabs will show the code as aligned in
another person's editor.

This new linter detects when tabs are being used for alignment and warns
about the presence of the tab.

Closes #153