### PR TITLE
Add a linter for checking instance variable usage

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -47,6 +47,13 @@ linters:
   ImplicitDiv:
     enabled: true
 
+  InstanceVariables:
+    enabled: true
+    file_types: partials
+    matchers:
+      all: .*
+      partials: \A_.*\.haml\z
+
   LeadingCommentSpace:
     enabled: true
 

--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -15,6 +15,7 @@ Below is a list of linters supported by `haml-lint`, ordered alphabetically.
 * [IdNames](#idnames)
 * [ImplicitDiv](#implicitdiv)
 * [Indentation](#indentation)
+* [InstanceVariables](#instancevariables)
 * [LeadingCommentSpace](#leadingcommentspace)
 * [LineLength](#linelength)
 * [MultilinePipe](#multilinepipe)
@@ -306,6 +307,36 @@ Check that spaces are used for indentation instead of hard tabs.
 Option          | Description
 ----------------|-------------------------------------------------------------
 `character`     | Character to use for indentation. `space` or `tab` (default `space`)
+
+## InstanceVariables
+
+Checks that instance variables are not used in the specified type of files.
+
+Option          | Description
+----------------|-------------------------------------------------------------
+`file_types`    | The class of files to lint (default `partial`)
+`matchers`      | The regular expressions to check file names against.
+
+By default, this linter only runs on Rails-style partial views, e.g. files that
+have a base name starting with a leading underscore `_`. If you want to ensure
+that you don't use any instance variables at all, you can set `file_types` to
+`all`.
+
+You can also define your own matchers if you want to enable this linter on
+a different subset of your views. For instance, if you want to lint only files
+starting with `special_`, you can define the configuration as follows:
+
+```yaml
+InstanceVariables:
+  enabled: true
+  file_types: special
+  matchers:
+    special: ^special_.*\.haml$
+```
+
+To avoid using instance variables in partials, ensure you are passing any needed
+variables as local variables. Alternatively, you can use only helper methods to
+place data in your views.
 
 ## LeadingCommentSpace
 

--- a/lib/haml_lint/linter/instance_variables.rb
+++ b/lib/haml_lint/linter/instance_variables.rb
@@ -1,0 +1,77 @@
+module HamlLint
+  # Checks for the presence of instance variables
+  class Linter::InstanceVariables < Linter
+    include LinterRegistry
+
+    # Enables the linter if the tree is for the right file type.
+    #
+    # @param [HamlLint::Tree::RootNode] the root of a syntax tree
+    # @return [true, false] whether the linter is enabled for the tree
+    def visit_root(node)
+      @enabled = matcher.match(File.basename(node.file)) ? true : false
+    end
+
+    # Checks for instance variables in script nodes when the linter is enabled.
+    #
+    # @param [HamlLint::Tree:ScriptNode]
+    # @return [void]
+    def visit_script(node)
+      return unless enabled?
+
+      if node.parsed_script.contains_instance_variables?
+        record_lint(node, "Avoid using instance variables in #{file_types} views")
+      end
+    end
+
+    # @!method visit_silent_script(node)
+    #   Checks for instance variables in script nodes when the linter is enabled.
+    #
+    #   @param [HamlLint::Tree:SilentScriptNode]
+    #   @return [void]
+    alias visit_silent_script visit_script
+
+    # Checks for instance variables in tag nodes when the linter is enabled.
+    #
+    # @param [HamlLint::Tree:TagNode]
+    # @return [void]
+    def visit_tag(node)
+      return unless enabled?
+
+      visit_script(node) ||
+        if node.parsed_attributes.contains_instance_variables?
+          record_lint(node, "Avoid using instance variables in #{file_types} views")
+        end
+    end
+
+    private
+
+    # Tracks whether the linter is enabled for the file.
+    #
+    # @api private
+    # @return [true, false]
+    attr_reader :enabled
+
+    # @!method enabled?
+    #   Checks whether the linter is enabled for the file.
+    #
+    #   @api private
+    #   @return [true, false]
+    alias enabled? enabled
+
+    # The type of files the linter is configured to check.
+    #
+    # @api private
+    # @return [String]
+    def file_types
+      @file_types ||= config['file_types'] || 'partial'
+    end
+
+    # The matcher to use for testing whether to check a file by file name.
+    #
+    # @api private
+    # @return [Regexp]
+    def matcher
+      @matcher ||= Regexp.new(config['matchers'][file_types] || '\A_.*\.haml\z')
+    end
+  end
+end

--- a/lib/haml_lint/parsed_ruby.rb
+++ b/lib/haml_lint/parsed_ruby.rb
@@ -1,0 +1,22 @@
+require 'delegate'
+
+module HamlLint
+  # A thin wrapper around the syntax tree from the Parser gem.
+  class ParsedRuby < SimpleDelegator
+    # !@method syntax_tree
+    #   Returns the bare syntax tree from the wrapper.
+    #
+    #   @api semipublic
+    #   @return [Array] syntax tree in the form returned by Parser gem
+    alias syntax_tree __getobj__
+
+    # Checks whether the syntax tree contains any instance variables.
+    #
+    # @return [true, false]
+    def contains_instance_variables?
+      return false unless syntax_tree
+
+      syntax_tree.ivar_type? || syntax_tree.each_descendant.any?(&:ivar_type?)
+    end
+  end
+end

--- a/lib/haml_lint/tree/root_node.rb
+++ b/lib/haml_lint/tree/root_node.rb
@@ -1,5 +1,11 @@
 module HamlLint::Tree
   # Represents the root node of a HAML document that contains all other nodes.
   class RootNode < Node
+    # The name fo the file parsed to build this tree.
+    #
+    # @return [String] a file name
+    def file
+      @document.file
+    end
   end
 end

--- a/lib/haml_lint/tree/script_node.rb
+++ b/lib/haml_lint/tree/script_node.rb
@@ -1,6 +1,15 @@
+require 'haml_lint/parsed_ruby'
+
 module HamlLint::Tree
   # Represents a node which produces output based on Ruby code.
   class ScriptNode < Node
+    # The Ruby script contents parsed into a syntax tree.
+    #
+    # @return [ParsedRuby] syntax tree in the form returned by Parser gem
+    def parsed_script
+      HamlLint::ParsedRuby.new(HamlLint::RubyParser.new.parse(script))
+    end
+
     # Returns the source for the script following the `-` marker.
     #
     # @return [String]

--- a/lib/haml_lint/tree/silent_script_node.rb
+++ b/lib/haml_lint/tree/silent_script_node.rb
@@ -2,6 +2,13 @@ module HamlLint::Tree
   # Represents a HAML silent script node (`- some_expression`) which executes
   # code without producing output.
   class SilentScriptNode < Node
+    # The Ruby script contents parsed into a syntax tree.
+    #
+    # @return [ParsedRuby] syntax tree in the form returned by Parser gem
+    def parsed_script
+      HamlLint::ParsedRuby.new(HamlLint::RubyParser.new.parse(script))
+    end
+
     # Returns the source for the script following the `-` marker.
     #
     # @return [String]

--- a/lib/haml_lint/tree/tag_node.rb
+++ b/lib/haml_lint/tree/tag_node.rb
@@ -180,6 +180,20 @@ module HamlLint::Tree
       @value[:object_ref][/\A\[(.*)\]\z/, 1] if object_reference?
     end
 
+    # The attributes given to the tag parsed into a Ruby syntax tree.
+    #
+    # @return [ParsedRuby] syntax tree in the form returned by Parser gem
+    def parsed_attributes
+      HamlLint::ParsedRuby.new(HamlLint::RubyParser.new.parse(hash_attributes_source || ''))
+    end
+
+    # The Ruby script contents of a tag parsed into a syntax tree.
+    #
+    # @return [ParsedRuby] syntax tree in the form returned by Parser gem
+    def parsed_script
+      HamlLint::ParsedRuby.new(HamlLint::RubyParser.new.parse(script || ''))
+    end
+
     # Whether this node had a `<` after it signifying that outer whitespace
     # should be removed.
     #
@@ -207,10 +221,6 @@ module HamlLint::Tree
     end
 
     private
-
-    def parsed_attributes
-      HamlLint::RubyParser.new.parse(hash_attributes_source)
-    end
 
     def existing_attributes
       parsed_attributes.children.collect do |parsed_attribute|

--- a/spec/haml_lint/linter/instance_variables_spec.rb
+++ b/spec/haml_lint/linter/instance_variables_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+RSpec.describe HamlLint::Linter::InstanceVariables do
+  include_context 'linter'
+
+  context 'when the file name does not match the matcher' do
+    let(:haml) { '%p= @greeting' }
+
+    it { should_not report_lint }
+  end
+
+  context 'when the file name matches the matcher' do
+    let(:options) do
+      {
+        config: HamlLint::ConfigurationLoader.default_configuration,
+        file: '_partial.html.haml'
+      }
+    end
+
+    context 'and there is not an instance variable' do
+      let(:haml) { '%p Hello, world' }
+
+      it { should_not report_lint }
+    end
+
+    context 'and there is an instance variable' do
+      context 'in a tag node' do
+        context 'as script' do
+          let(:haml) { '%p= @greeting' }
+
+          it { should report_lint line: 1 }
+        end
+
+        context 'as an attribute' do
+          let(:haml) { '%p{ name: @greeting }' }
+
+          it { should report_lint line: 1 }
+        end
+      end
+
+      context 'in a script node' do
+        let(:haml) { '= :blah && @greeting' }
+
+        it { should report_lint line: 1 }
+      end
+
+      context 'in a silent script node' do
+        let(:haml) { '- hello = @greeting' }
+
+        it { should report_lint line: 1 }
+      end
+    end
+  end
+
+  context 'with a custom matcher' do
+    let(:haml) { '%p= @greeting' }
+    let(:full_config) do
+      HamlLint::Configuration.new(
+        'linters' => {
+          'InstanceVariables' => {
+            'file_types' => 'my_custom',
+            'matchers' => {
+              'my_custom' => '\Apartial_.*\.haml\z'
+            }
+          }
+        }
+      )
+    end
+
+    let(:options) do
+      {
+        config: full_config,
+        file: file
+      }
+    end
+
+    context 'that matches the file name' do
+      let(:file) { 'partial_view.html.haml' }
+
+      it { should report_lint line: 1 }
+    end
+
+    context 'that does not match the file name' do
+      let(:file) { 'view.html.haml' }
+
+      it { should_not report_lint }
+    end
+  end
+end

--- a/spec/support/shared_linter_context.rb
+++ b/spec/support/shared_linter_context.rb
@@ -10,9 +10,9 @@ shared_context 'linter' do
 
   let(:config) { options[:config].for_linter(described_class) }
 
+  let(:document) { HamlLint::Document.new(normalize_indent(haml), options) }
+
   subject { described_class.new(config) }
 
-  before do
-    subject.run(HamlLint::Document.new(normalize_indent(haml), options))
-  end
+  before { subject.run(document) }
 end


### PR DESCRIPTION
It is fairly common to recommend that partials only use local variables
and helper methods and avoid the use of instance variables. This linter
checks views that follow partial conventions (prefixed with an
underscore) and checks that partials do not use instance variables.

The linter is also configurable, by default, to forbid the use of
instance variables in all views for those who wish to only use helper
methods in their views.

Lastly, it can be configured to accept any regular expression to match
against file names.

Closes #121