### PR TITLE
Add a HashReporter for other tools to use

### DIFF
--- a/lib/haml_lint/reporter/hash_reporter.rb
+++ b/lib/haml_lint/reporter/hash_reporter.rb
@@ -1,0 +1,51 @@
+module HamlLint
+  # Outputs report as a Ruby Hash for easy use by other tools.
+  class Reporter::HashReporter < Reporter
+    def display_report(report)
+      lints = report.lints
+      grouped = lints.group_by(&:filename)
+
+      report_hash = {
+        metadata: metadata,
+        files: grouped.map { |l| map_file(l) },
+        summary: {
+          offense_count: lints.length,
+          target_file_count: grouped.length,
+          inspected_file_count: report.files.length,
+        },
+      }
+
+      report_hash
+    end
+
+    private
+
+    def metadata
+      {
+        haml_lint_version: HamlLint::VERSION,
+        ruby_engine:      RUBY_ENGINE,
+        ruby_patchlevel:  RUBY_PATCHLEVEL.to_s,
+        ruby_platform:    RUBY_PLATFORM,
+      }
+    end
+
+    def map_file(file)
+      {
+        path: file.first,
+        offenses: file.last.map { |o| map_offense(o) },
+      }
+    end
+
+    def map_offense(offense)
+      {
+        severity: offense.severity,
+        message: offense.message,
+        location: {
+          line: offense.line,
+        },
+      }.tap do |h|
+        h[:linter_name] = offense.linter.name if offense.linter
+      end
+    end
+  end
+end

--- a/lib/haml_lint/reporter/json_reporter.rb
+++ b/lib/haml_lint/reporter/json_reporter.rb
@@ -1,51 +1,8 @@
 module HamlLint
   # Outputs report as a JSON document.
-  class Reporter::JsonReporter < Reporter
+  class Reporter::JsonReporter < Reporter::HashReporter
     def display_report(report)
-      lints = report.lints
-      grouped = lints.group_by(&:filename)
-
-      report_hash = {
-        metadata: metadata,
-        files: grouped.map { |l| map_file(l) },
-        summary: {
-          offense_count: lints.length,
-          target_file_count: grouped.length,
-          inspected_file_count: report.files.length,
-        },
-      }
-
-      log.log report_hash.to_json
-    end
-
-    private
-
-    def metadata
-      {
-        haml_lint_version: HamlLint::VERSION,
-        ruby_engine:      RUBY_ENGINE,
-        ruby_patchlevel:  RUBY_PATCHLEVEL.to_s,
-        ruby_platform:    RUBY_PLATFORM,
-      }
-    end
-
-    def map_file(file)
-      {
-        path: file.first,
-        offenses: file.last.map { |o| map_offense(o) },
-      }
-    end
-
-    def map_offense(offense)
-      {
-        severity: offense.severity,
-        message: offense.message,
-        location: {
-          line: offense.line,
-        },
-      }.tap do |h|
-        h[:linter_name] = offense.linter.name if offense.linter
-      end
+      log.log super.to_json
     end
   end
 end


### PR DESCRIPTION
Currently, the Code Climate engine I've been working on has to go
through [a dance] to capture the JSON output of a report. By extracting
the hash construction into a reporter that can be used by tools outside
of Haml-Lint proper, we can encourage others to write such tools.

The existing structure of the JSON reporter is really nice, so this
extracts that behavior and makes the existing JSON reporter a subclass
that only handles the printing of the report to the log.

[a dance]: https://github.com/michaelherold/codeclimate-haml_lint/blob/ac22d320e95ebb476fb25551eb6fa3513d2a61b8/lib/cc/engine/report_adapter.rb