### PR TITLE
Add support for incremental processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Command Line Flag         | Description
 `-i`/`--include-linter`   | Specify which linters you specifically want to run
 `-x`/`--exclude-linter`   | Specify which linters you _don't_ want to run
 `-r`/`--reporter`         | Specify which reporter you want to use to generate the output
+`--fail-fast`             | Specify whether to fail after the first file with lint
+`--fail-level`            | Specify the severity above which the lint should fail
 `--[no-]color`            | Whether to output in color
 `--[no-]summary`          | Whether to output a summary in the default reporter
 `--show-linters`          | Show all registered linters

--- a/haml_lint.gemspec
+++ b/haml_lint.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_dependency 'haml', '>= 4.0', '< 5.1'
+  s.add_dependency 'rainbow'
   s.add_dependency 'rake', '>= 10', '< 13'
   s.add_dependency 'rubocop', '>= 0.47.0'
   s.add_dependency 'sysexits', '~> 1.1'

--- a/lib/haml_lint/cli.rb
+++ b/lib/haml_lint/cli.rb
@@ -87,16 +87,11 @@ module HamlLint
     #
     # @return [Integer] exit status code
     def scan_for_lints(options)
-      report = Runner.new.run(options)
-      print_report(report, options)
-      report.failed? ? Sysexits::EX_DATAERR : Sysexits::EX_OK
-    end
-
-    # Outputs a report of the linter run using the specified reporter.
-    def print_report(report, options)
       reporter = options.fetch(:reporter,
                                HamlLint::Reporter::DefaultReporter).new(log)
-      reporter.display_report(report)
+      report = Runner.new.run(options.merge(reporter: reporter))
+      report.display
+      report.failed? ? Sysexits::EX_DATAERR : Sysexits::EX_OK
     end
 
     # Outputs a list of all currently available linters.

--- a/lib/haml_lint/options.rb
+++ b/lib/haml_lint/options.rb
@@ -47,6 +47,10 @@ module HamlLint
         @options[:reporter] = load_reporter_class(reporter.capitalize)
       end
 
+      parser.on('--fail-fast', 'Fail after the first file with lint above the fail level') do
+        @options[:fail_fast] = true
+      end
+
       parser.on('--fail-level fail_level', String,
                 'Specify which level you want the suite to fail') do |fail_level|
         @options[:fail_level] = HamlLint::Severity.new(fail_level.to_sym)

--- a/lib/haml_lint/report.rb
+++ b/lib/haml_lint/report.rb
@@ -15,10 +15,28 @@ module HamlLint
     # @param lints [Array<HamlLint::Lint>] lints that were found
     # @param files [Array<String>] files that were linted
     # @param fail_level [Symbol] the severity level to fail on
-    def initialize(lints, files, fail_level = :warning)
+    # @param reporter [HamlLint::Reporter] the reporter for the report
+    def initialize(lints = [], files = [], fail_level = :warning, reporter:)
       @lints = lints.sort_by { |l| [l.filename, l.line] }
       @files = files
       @fail_level = Severity.new(fail_level)
+      @reporter = reporter
+    end
+
+    # Adds a lint to the report and notifies the reporter.
+    #
+    # @param lint [HamlLint::Lint] lint to add
+    # @return [void]
+    def add_lint(lint)
+      lints << lint
+      @reporter.added_lint(lint)
+    end
+
+    # Displays the report via the configured reporter.
+    #
+    # @return [void]
+    def display
+      @reporter.display_report(self)
     end
 
     # Checks whether any lints were over the fail level
@@ -26,6 +44,24 @@ module HamlLint
     # @return [Boolean]
     def failed?
       @lints.any? { |lint| lint.severity >= fail_level }
+    end
+
+    # Adds a file to the list of linted files and notifies the reporter.
+    #
+    # @param file [String] the name of the file that was finished
+    # @param lints [Array<HamlLint::Lint>] the lints for the finished file
+    # @return [void]
+    def finish_file(file, lints)
+      files << file
+      @reporter.finished_file(file, lints)
+    end
+
+    # Notifies the reporter that the report has started.
+    #
+    # @param files [Array<String>] the files to lint
+    # @return [void]
+    def start(files)
+      @reporter.start(files)
     end
   end
 end

--- a/lib/haml_lint/reporter.rb
+++ b/lib/haml_lint/reporter.rb
@@ -1,9 +1,13 @@
+require 'haml_lint/reporter/hooks'
+
 module HamlLint
   # Abstract lint reporter. Subclass and override {#display_report} to
   # implement a custom lint reporter.
   #
   # @abstract
   class Reporter
+    include Reporter::Hooks
+
     # Creates the reporter that will display the given report.
     #
     # @param logger [HamlLint::Logger]

--- a/lib/haml_lint/reporter/default_reporter.rb
+++ b/lib/haml_lint/reporter/default_reporter.rb
@@ -1,73 +1,17 @@
+require 'haml_lint/reporter/utils'
+
 module HamlLint
   # Outputs lints in a simple format with the filename, line number, and lint
   # message.
   class Reporter::DefaultReporter < Reporter
+    include Reporter::Utils
+
+    def added_lint(lint)
+      print_lint(lint)
+    end
+
     def display_report(report)
-      sorted_lints = report.lints.sort_by { |l| [l.filename, l.line] }
-
-      sorted_lints.each do |lint|
-        print_location(lint)
-        print_type(lint)
-        print_message(lint)
-      end
-
       print_summary(report)
-    end
-
-    private
-
-    def pluralize(word, count: 1)
-      if count.zero? || count > 1
-        "#{count} #{word}s"
-      else
-        "#{count} #{word}"
-      end
-    end
-
-    def print_location(lint)
-      log.info lint.filename, false
-      log.log ':', false
-      log.bold lint.line, false
-    end
-
-    def print_type(lint)
-      if lint.error?
-        log.error ' [E] ', false
-      else
-        log.warning ' [W] ', false
-      end
-    end
-
-    def print_message(lint)
-      if lint.linter
-        log.success("#{lint.linter.name}: ", false)
-      end
-
-      log.log lint.message
-    end
-
-    def print_summary(report)
-      return unless log.summary_enabled
-
-      print_summary_files(report)
-      print_summary_lints(report)
-
-      log.log ' detected'
-    end
-
-    def print_summary_files(report)
-      log.log "\n#{pluralize('file', count: report.files.count)} inspected, ", false
-    end
-
-    def print_summary_lints(report)
-      lint_count = report.lints.size
-      lint_message = pluralize('lint', count: lint_count)
-
-      if lint_count == 0
-        log.log lint_message, false
-      else
-        log.error lint_message, false
-      end
     end
   end
 end

--- a/lib/haml_lint/reporter/hooks.rb
+++ b/lib/haml_lint/reporter/hooks.rb
@@ -1,0 +1,25 @@
+module HamlLint
+  class Reporter
+    # A collection of hook methods for incremental processing.
+    module Hooks
+      # A hook that is called for each lint as it is detected.
+      #
+      # @param _lint [HamlLint::Lint] the lint added to the report
+      # @return [void]
+      def added_lint(_lint); end
+
+      # A hook that is called for each file as it is finished processing.
+      #
+      # @param _file [String] the name of the file that just finished
+      # @param _lints [Array<HamlLint::Lint>] the lints added to the report
+      # @return [void]
+      def finished_file(_file, _lints); end
+
+      # A hook that is called when the processing starts.
+      #
+      # @param _files [Array<String>] the names of the files to be processed
+      # @return [void]
+      def start(_files); end
+    end
+  end
+end

--- a/lib/haml_lint/reporter/progress_reporter.rb
+++ b/lib/haml_lint/reporter/progress_reporter.rb
@@ -1,0 +1,47 @@
+require 'rainbow'
+require 'haml_lint/reporter/utils'
+
+module HamlLint
+  # Outputs files as they are output as a simple symbol, then outputs
+  # a summary of each lint.
+  class Reporter::ProgressReporter < Reporter
+    include Reporter::Utils
+
+    DOT = '.'.freeze
+
+    def display_report(report)
+      lints = report.lints
+
+      log.log("\n\nOffenses:\n", true) if lints.any?
+      lints.each { |lint| print_lint(lint) }
+
+      print_summary(report)
+    end
+
+    def finished_file(_file, lints)
+      report_file_as_mark(lints)
+    end
+
+    def start(files)
+      log.log("Inspecting #{pluralize('file', count: files.size)}", true)
+    end
+
+    private
+
+    def dot
+      @dot ||= Rainbow(DOT).green
+    end
+
+    def report_file_as_mark(lints)
+      mark =
+        if lints.empty?
+          dot
+        else
+          worst_lint = lints.max_by(&:severity)
+          worst_lint.severity.mark_with_color
+        end
+
+      log.log(mark, false)
+    end
+  end
+end

--- a/lib/haml_lint/reporter/utils.rb
+++ b/lib/haml_lint/reporter/utils.rb
@@ -1,0 +1,101 @@
+module HamlLint
+  class Reporter
+    # Formatting helpers for printing the default report format.
+    module Utils
+      # Pluralizes a word based on a count.
+      #
+      # @param word [String] the word to pluralize
+      # @param count [Integer] the count of items
+      # @return [String]
+      def pluralize(word, count: 1)
+        if count.zero? || count > 1
+          "#{count} #{word}s"
+        else
+          "#{count} #{word}"
+        end
+      end
+
+      # Prints the lint with its location and severity.
+      #
+      # @param lint [HamlLint::Lint] the lint to print
+      # @return [void]
+      def print_lint(lint)
+        print_location(lint)
+        print_type(lint)
+        print_message(lint)
+      end
+
+      # Prints the location of a lint.
+      #
+      # @param lint [HamlLint::Lint] the lint to print
+      # @return [void]
+      def print_location(lint)
+        log.info lint.filename, false
+        log.log ':', false
+        log.bold lint.line, false
+      end
+
+      # Prints the severity of a lint.
+      #
+      # @param lint [HamlLint::Lint] the lint to print
+      # @return [void]
+      def print_type(lint)
+        message = " [#{lint.severity.mark}] "
+
+        if lint.error?
+          log.error message, false
+        else
+          log.warning message, false
+        end
+      end
+
+      # Prints the description of a lint.
+      #
+      # @param lint [HamlLint::Lint] the lint to print
+      # @return [void]
+      def print_message(lint)
+        if lint.linter
+          log.success("#{lint.linter.name}: ", false)
+        end
+
+        log.log lint.message
+      end
+
+      # Prints a summary of a report when summaries are enabled.
+      #
+      # @param report [HamlLint::Report] the report to print
+      # @return [void]
+      def print_summary(report)
+        return unless log.summary_enabled
+
+        print_summary_files(report)
+        print_summary_lints(report)
+
+        log.log ' detected'
+      end
+
+      # Prints a summary of the number of files linted in a report.
+      #
+      # @param report [HamlLint::Report] the report to print
+      # @return [void]
+      def print_summary_files(report)
+        log.log "\n#{pluralize('file', count: report.files.count)} inspected, ", false
+      end
+
+      # Prints a summary of the number of lints found in a report.
+      #
+      # @param report [HamlLint::Report] the report to print
+      # @return [void]
+      def print_summary_lints(report)
+        lint_count = report.lints.size
+        lint_message = pluralize('lint', count: lint_count)
+
+        if lint_count == 0
+          log.log lint_message, false
+        else
+          log.error lint_message, false
+        end
+      end
+    end
+  end
+end

--- a/lib/haml_lint/runner.rb
+++ b/lib/haml_lint/runner.rb
@@ -10,22 +10,46 @@ module HamlLint
     # @option options :excluded_files [Array<String>]
     # @option options :included_linters [Array<String>]
     # @option options :excluded_linters [Array<String>]
+    # @option options :fail_fast [true, false] flag for failing after first failure
     # @option options :fail_level
+    # @option options :reporter [HamlLint::Reporter]
     # @return [HamlLint::Report] a summary of all lints found
     def run(options = {})
-      config = load_applicable_config(options)
-      files = extract_applicable_files(config, options)
+      @config = load_applicable_config(options)
+      @files = extract_applicable_files(config, options)
+      @linter_selector = HamlLint::LinterSelector.new(config, options)
+      @fail_fast = options.fetch(:fail_fast, false)
 
-      linter_selector = HamlLint::LinterSelector.new(config, options)
-
-      lints = files.map do |file|
-        collect_lints(file, linter_selector, config)
-      end.flatten
-
-      HamlLint::Report.new(lints, files, options[:fail_level])
+      report(options)
     end
 
     private
+
+    # The {HamlLint::Configuration} that should be used for this run.
+    #
+    # @return [HamlLint::Configuration]
+    attr_reader :config
+
+    # A flag for whether to fail after the first failure.
+    #
+    # @return [true, false]
+    attr_reader :fail_fast
+
+    # !@method fail_fast?
+    #   Checks whether to fail after the first failure.
+    #
+    #   @return [true, false]
+    alias fail_fast? fail_fast
+
+    # The list of files to lint during this run.
+    #
+    # @return [Array<String>]
+    attr_reader :files
+
+    # The selector for which linters to run during this run.
+    #
+    # @return [HamlLint::LinterSelector]
+    attr_reader :linter_selector
 
     # Returns the {HamlLint::Configuration} that should be used given the
     # specified options.
@@ -73,6 +97,40 @@ module HamlLint
       excluded_patterns += options.fetch(:excluded_files, [])
 
       HamlLint::FileFinder.new(config).find(included_patterns, excluded_patterns)
+    end
+
+    # Process the files and add them to the given report.
+    #
+    # @param report [HamlLint::Report]
+    # @return [void]
+    def process_files(report)
+      files.each do |file|
+        process_file(file, report)
+        break if report.failed? && fail_fast?
+      end
+    end
+
+    # Process a file and add it to the given report.
+    #
+    # @param file [String] the name of the file to process
+    # @param report [HamlLint::Report]
+    # @return [void]
+    def process_file(file, report)
+      lints = collect_lints(file, linter_selector, config)
+      lints.each { |lint| report.add_lint(lint) }
+      report.finish_file(file, lints)
+    end
+
+    # Generates a report based on the given options.
+    #
+    # @param options [Hash]
+    # @option options :reporter [HamlLint::Reporter] the reporter to report with
+    # @return [HamlLint::Report]
+    def report(options)
+      report = HamlLint::Report.new(reporter: options[:reporter])
+      report.start(@files)
+      process_files(report)
+      report
     end
   end
 end

--- a/lib/haml_lint/severity.rb
+++ b/lib/haml_lint/severity.rb
@@ -8,6 +8,8 @@ module HamlLint
     SEVERITY_ERROR = :error
     SEVERITY_WARNING = :warning
 
+    COLORS = { error: :red, warning: :yellow }.freeze
+    MARKS = { error: 'E', warning: 'W' }.freeze
     NAMES = [SEVERITY_WARNING, SEVERITY_ERROR].freeze
 
     # Creates a new severity for a lint
@@ -22,6 +24,13 @@ module HamlLint
       name ||= :warning
       fail Exceptions::UnknownSeverity, "Unknown severity: #{name}" unless NAMES.include?(name)
       super
+    end
+
+    # The color of the mark in reporters.
+    #
+    # @return [Symbol]
+    def color
+      COLORS[__getobj__]
     end
 
     # Checks whether the severity is an error
@@ -43,6 +52,23 @@ module HamlLint
       NAMES.index(__getobj__) + 1
     end
 
+    # The symbol to use in a {HamlLint::Reporter::ProgressReporter}.
+    #
+    # @returns [String]
+    def mark
+      MARKS[__getobj__]
+    end
+
+    # The colorized symbol to use in a reporter.
+    #
+    # @returns [String]
+    def mark_with_color
+      Rainbow.global.wrap(mark).public_send(color)
+    end
+
+    # The name of the severity.
+    #
+    # @returns [Symbol]
     def name
       __getobj__
     end

--- a/spec/haml_lint/options_spec.rb
+++ b/spec/haml_lint/options_spec.rb
@@ -81,6 +81,14 @@ describe HamlLint::Options do
       end
     end
 
+    context 'fail fast' do
+      let(:args) { %w[--fail-fast] }
+
+      it 'sets the fail_fast option' do
+        subject[:fail_fast].should == true
+      end
+    end
+
     context 'with the help option' do
       let(:args) { ['--help'] }
 

--- a/spec/haml_lint/report_spec.rb
+++ b/spec/haml_lint/report_spec.rb
@@ -4,8 +4,10 @@ RSpec.describe HamlLint::Report do
   let(:fail_level) { :warning }
   let(:filenames) { ['some-filename.haml'] }
   let(:lints) { [] }
+  let(:logger) { HamlLint::Logger.new(StringIO.new) }
+  let(:reporter) { HamlLint::Reporter::DefaultReporter.new(logger) }
 
-  subject(:report) { described_class.new(lints, filenames, fail_level) }
+  subject(:report) { described_class.new(lints, filenames, fail_level, reporter: reporter) }
 
   describe '#failed?' do
     subject { report.failed? }

--- a/spec/haml_lint/reporter/checkstyle_reporter_spec.rb
+++ b/spec/haml_lint/reporter/checkstyle_reporter_spec.rb
@@ -5,7 +5,7 @@ describe HamlLint::Reporter::CheckstyleReporter do
     let(:io) { StringIO.new }
     let(:output) { io.string }
     let(:logger) { HamlLint::Logger.new(io) }
-    let(:report) { HamlLint::Report.new(lints, []) }
+    let(:report) { HamlLint::Report.new(lints, [], reporter: reporter) }
     let(:reporter) { described_class.new(logger) }
     let(:linter) { HamlLint::Linter::FinalNewline }
 

--- a/spec/haml_lint/reporter/default_reporter_spec.rb
+++ b/spec/haml_lint/reporter/default_reporter_spec.rb
@@ -1,15 +1,110 @@
 require 'spec_helper'
 
 describe HamlLint::Reporter::DefaultReporter do
-  describe '#display_report' do
-    let(:filenames) { %w[some-filename.haml] }
-    let(:io) { StringIO.new }
-    let(:output) { io.string }
-    let(:output_without_summary) { output.split("\n")[0..-2].join("\n") }
-    let(:logger) { HamlLint::Logger.new(io) }
-    let(:report) { HamlLint::Report.new(lints, filenames) }
-    let(:reporter) { described_class.new(logger) }
+  let(:filenames) { %w[some-filename.haml] }
+  let(:io) { StringIO.new }
+  let(:output) { io.string }
+  let(:logger) { HamlLint::Logger.new(io) }
+  let(:report) { HamlLint::Report.new(lints, filenames, reporter: reporter) }
+  let(:reporter) { described_class.new(logger) }
 
+  describe '#added_lint' do
+    subject { lints.each { |lint| reporter.added_lint(lint) } }
+
+    context 'when there are no lints' do
+      let(:lints) { [] }
+
+      it 'prints nothing' do
+        subject
+        output.should == ''
+      end
+    end
+
+    context 'when there are lints' do
+      let(:filenames)    { ['some-filename.haml', 'other-filename.haml'] }
+      let(:lines)        { [502, 724] }
+      let(:descriptions) { ['Description of lint 1', 'Description of lint 2'] }
+      let(:severities)   { [:warning] * 2 }
+      let(:linter)       { double(name: 'SomeLinter') }
+
+      let(:lints) do
+        filenames.each_with_index.map do |filename, index|
+          HamlLint::Lint.new(linter, filename, lines[index], descriptions[index], severities[index])
+        end
+      end
+
+      it 'prints each lint on its own line' do
+        subject
+        output.count("\n").should == 2
+      end
+
+      it 'prints a trailing newline' do
+        subject
+        output[-1].should == "\n"
+      end
+
+      it 'prints the filename for each lint' do
+        subject
+        filenames.each do |filename|
+          output.scan(/#{filename}/).count.should == 1
+        end
+      end
+
+      it 'prints the line number for each lint' do
+        subject
+        lines.each do |line|
+          output.scan(/#{line}/).count.should == 1
+        end
+      end
+
+      it 'prints the description for each lint' do
+        subject
+        descriptions.each do |description|
+          output.scan(/#{description}/).count.should == 1
+        end
+      end
+
+      it 'prints the linter name for each lint' do
+        subject
+        output.split("\n").each do |line|
+          line.scan(/#{linter.name}/).count.should == 1
+        end
+      end
+
+      context 'when lints are warnings' do
+        it 'prints the warning severity code on each line' do
+          subject
+          output.split("\n").each do |line|
+            line.scan(/\[W\]/).count.should == 1
+          end
+        end
+      end
+
+      context 'when lints are errors' do
+        let(:severities) { [:error] * 2 }
+
+        it 'prints the error severity code on each line' do
+          subject
+          output.split("\n").each do |line|
+            line.scan(/\[E\]/).count.should == 1
+          end
+        end
+      end
+
+      context 'when lint has no associated linter' do
+        let(:linter) { nil }
+
+        it 'prints the description for each lint' do
+          subject
+          descriptions.each do |description|
+            output.scan(/#{description}/).count.should == 1
+          end
+        end
+      end
+    end
+  end
+
+  describe '#display_report' do
     subject { reporter.display_report(report) }
 
     context 'when there are no lints' do
@@ -43,73 +138,9 @@ describe HamlLint::Reporter::DefaultReporter do
         end
       end
 
-      it 'prints each lint and the summary on its own line' do
+      it 'prints the summary' do
         subject
-        output_without_summary.count("\n").should == 2
-      end
-
-      it 'prints a trailing newline' do
-        subject
-        output[-1].should == "\n"
-      end
-
-      it 'prints the filename for each lint' do
-        subject
-        filenames.each do |filename|
-          output.scan(/#{filename}/).count.should == 1
-        end
-      end
-
-      it 'prints the line number for each lint' do
-        subject
-        lines.each do |line|
-          output.scan(/#{line}/).count.should == 1
-        end
-      end
-
-      it 'prints the description for each lint' do
-        subject
-        descriptions.each do |description|
-          output.scan(/#{description}/).count.should == 1
-        end
-      end
-
-      it 'prints the linter name for each lint' do
-        subject
-        output_without_summary.split("\n").each do |line|
-          line.scan(/#{linter.name}/).count.should == 1
-        end
-      end
-
-      context 'when lints are warnings' do
-        it 'prints the warning severity code on each line' do
-          subject
-          output_without_summary.split("\n").each do |line|
-            line.scan(/\[W\]/).count.should == 1
-          end
-        end
-      end
-
-      context 'when lints are errors' do
-        let(:severities) { [:error] * 2 }
-
-        it 'prints the error severity code on each line' do
-          subject
-          output_without_summary.split("\n").each do |line|
-            line.scan(/\[E\]/).count.should == 1
-          end
-        end
-      end
-
-      context 'when lint has no associated linter' do
-        let(:linter) { nil }
-
-        it 'prints the description for each lint' do
-          subject
-          descriptions.each do |description|
-            output.scan(/#{description}/).count.should == 1
-          end
-        end
+        output.should == "\n2 files inspected, 2 lints detected\n"
       end
     end
   end

--- a/spec/haml_lint/reporter/json_reporter_spec.rb
+++ b/spec/haml_lint/reporter/json_reporter_spec.rb
@@ -5,7 +5,7 @@ describe HamlLint::Reporter::JsonReporter do
     let(:io) { StringIO.new }
     let(:output) { JSON.parse(io.string) }
     let(:logger) { HamlLint::Logger.new(io) }
-    let(:report) { HamlLint::Report.new(lints, []) }
+    let(:report) { HamlLint::Report.new(lints, [], reporter: reporter) }
     let(:reporter) { described_class.new(logger) }
     let(:offenses) { output['files'].flat_map { |f| f['offenses'] } }
 

--- a/spec/haml_lint/reporter/progress_reporter_spec.rb
+++ b/spec/haml_lint/reporter/progress_reporter_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+
+RSpec.describe HamlLint::Reporter::ProgressReporter do
+  let(:files)    { ['some-filename.haml'] }
+  let(:io)       { StringIO.new }
+  let(:output)   { io.string }
+  let(:logger)   { HamlLint::Logger.new(io) }
+  let(:report)   { HamlLint::Report.new(lints, files, reporter: reporter) }
+  let(:reporter) { described_class.new(logger) }
+
+  describe '#finished_file' do
+    subject { files.each { |file| reporter.finished_file(file, lints) } }
+
+    context 'when there are no lints' do
+      let(:files) { ['some-filename.haml', 'other-filename.haml'] }
+      let(:lints) { [] }
+
+      it 'prints a dot for every file' do
+        subject
+        output.should eq('..')
+      end
+    end
+
+    context 'when there are lints' do
+      let(:descriptions) { ['Description of lint 1'] }
+      let(:lines)        { [502] }
+      let(:linter)       { double(name: 'SomeLinter') }
+
+      let(:lints) do
+        files.flat_map do |filename|
+          descriptions.each_with_index.map do |descriptions, index|
+            HamlLint::Lint.new(linter, filename, lines[index], descriptions, severities[index])
+          end
+        end
+      end
+
+      context 'when a warning severity offense is detected' do
+        let(:severities) { %i[warning] }
+
+        it 'prints a W' do
+          subject
+          output.should == 'W'
+        end
+      end
+
+      context 'when an error severity code is detected' do
+        let(:severities) { %i[error] }
+
+        it 'prints an E' do
+          subject
+          output.should == 'E'
+        end
+      end
+
+      context 'when different severity levels are detected' do
+        let(:descriptions) { ['Description of lint 1', 'Description of lint 2'] }
+        let(:lines)        { [502, 503] }
+        let(:linter)       { double(name: 'SomeLinter') }
+        let(:severities)   { %i[warning error] }
+
+        it 'prints the mark for the worst lint' do
+          subject
+          output.should == 'E'
+        end
+      end
+    end
+
+    describe '#display_report' do
+      subject { reporter.display_report(report) }
+
+      context 'when there are no lints' do
+        let(:files) { ['some-filename.haml', 'other-filename.haml'] }
+        let(:lints) { [] }
+
+        it 'prints the summary' do
+          subject
+          output.should == "\n2 files inspected, 0 lints detected\n"
+        end
+      end
+
+      context 'when there are lints' do
+        let(:files)        { ['some-filename.haml', 'other-filename.haml'] }
+        let(:lines)        { [502, 724] }
+        let(:descriptions) { ['Description of lint 1', 'Description of lint 2'] }
+        let(:header)       { output.split("\n")[0..3].join("\n") }
+        let(:linter)       { double(name: 'SomeLinter') }
+        let(:offenses)     { output_without_summary.split("\n")[1..-1].join("\n") }
+        let(:output_without_summary) { output.split("\n").reject(&:empty?)[0..-2].join("\n") }
+        let(:severities)   { [:warning] * 2 }
+        let(:summary)      { output.split("\n")[-2..-1].join("\n") }
+
+        let(:lints) do
+          files.each_with_index.map do |file, index|
+            HamlLint::Lint.new(linter, file, lines[index], descriptions[index], severities[index])
+          end
+        end
+
+        it 'prints the header' do
+          subject
+          header.should == "\n\nOffenses:\n"
+        end
+
+        it 'prints each lint on its own line' do
+          subject
+          offenses.split("\n").size.should == 2
+        end
+
+        it 'prints the summary' do
+          subject
+          summary.should == "\n2 files inspected, 2 lints detected"
+        end
+      end
+    end
+
+    describe '#start' do
+      subject { reporter.start(files) }
+
+      it 'states the number of files to inspect' do
+        subject
+        output.should == "Inspecting 1 file\n"
+      end
+    end
+  end
+end

--- a/spec/haml_lint/runner_spec.rb
+++ b/spec/haml_lint/runner_spec.rb
@@ -1,8 +1,10 @@
 require 'spec_helper'
 
 describe HamlLint::Runner do
-  let(:options) { {} }
-  let(:runner)  { described_class.new }
+  let(:base_options) { { reporter: reporter } }
+  let(:options) { base_options }
+  let(:reporter) { HamlLint::Reporter::HashReporter.new(StringIO.new) }
+  let(:runner) { described_class.new }
 
   before do
     runner.stub(:extract_applicable_files).and_return(files)
@@ -13,9 +15,7 @@ describe HamlLint::Runner do
     let(:mock_linter) { double('linter', lints: [], name: 'Blah') }
 
     let(:options) do
-      {
-        files: files,
-      }
+      base_options.merge(files: files, reporter: reporter)
     end
 
     subject { runner.run(options) }
@@ -30,7 +30,7 @@ describe HamlLint::Runner do
     end
 
     context 'when :config_file option is specified' do
-      let(:options) { { config_file: 'some-config.yml' } }
+      let(:options) { base_options.merge(config_file: 'some-config.yml') }
       let(:config) { double('config') }
 
       it 'loads that specified configuration file' do
@@ -44,7 +44,7 @@ describe HamlLint::Runner do
     end
 
     context 'when `exclude` global config option specifies a list of patterns' do
-      let(:options) { { config: config, files: files } }
+      let(:options) { base_options.merge(config: config, files: files) }
       let(:config) { HamlLint::Configuration.new(config_hash) }
       let(:config_hash) { { 'exclude' => 'exclude-this-file.slim' } }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,10 @@ else
   require 'simplecov'
 end
 
+# Disable colors in tests because we don't normally want to test it
+require 'rainbow'
+Rainbow.enabled = false
+
 require 'haml_lint'
 require 'rspec/its'
 


### PR DESCRIPTION
This comes with two major features:

* The `--fail-fast` flag makes the linter fail after the first file that
  has a lint above the given fail level.
* The `--reporter progress` flag enables the use of the progress
  reporter. This new reporter prints a symbol for each linted file as it
  is linted. If the file has no lint, the reporter prints a ".", if
  there is a warning, the reporter prints a "W", and if there is an
  error the reporter prints an "E".

The incremental processing is handled via a series of hooks that are
called after certain actions within the runner. This is an extensible
system that can allow us to add more events in the future.

Closes #80
Closes #146