### PR TITLE
Add a RepeatedId Linter

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -70,6 +70,10 @@ linters:
   ObjectReferenceAttributes:
     enabled: true
 
+  RepeatedId:
+    enabled: true
+    severity: error
+
   RuboCop:
     enabled: true
     # These cops are incredibly noisy when it comes to HAML templates, so we

--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -21,6 +21,7 @@ Below is a list of linters supported by `haml-lint`, ordered alphabetically.
 * [MultilinePipe](#multilinepipe)
 * [MultilineScript](#multilinescript)
 * [ObjectReferenceAttributes](#objectreferenceattributes)
+* [RepeatedId](#repeatedid)
 * [RuboCop](#rubocop)
 * [RubyComments](#rubycomments)
 * [SpaceBeforeScript](#spacebeforescript)
@@ -477,6 +478,25 @@ where in your code a particular class attribute is defined. It is also tied
 directly to the class names of the objects you pass to it, creating an
 unnecessary coupling which can make refactoring your models affect your
 views.
+
+## RepeatedId
+
+The `id` attribute [must be unique] on the page since is intended to be a unique
+identifier. Repeating an `id` is an error in the HTML specification.
+
+**Bad**
+```haml
+#my-id
+#my-id
+```
+
+**Better**
+```haml
+#my-id
+#my-id-2
+```
+
+[must be unique]: https://www.w3.org/TR/html5/dom.html#the-id-attribute
 
 ## RuboCop
 

--- a/lib/haml_lint/linter/repeated_id.rb
+++ b/lib/haml_lint/linter/repeated_id.rb
@@ -1,0 +1,34 @@
+module HamlLint
+  # Detects repeated instances of an element ID in a file
+  class Linter::RepeatedId < Linter
+    include LinterRegistry
+
+    MESSAGE_FORMAT = %{Do not repeat id "#%s" on the page}.freeze
+
+    def visit_tag(node)
+      id = node.tag_id
+      return unless id && !id.empty?
+
+      nodes = (id_map[id] << node)
+      case nodes.size
+      when 1 then return
+      when 2 then add_lints_for_first_duplications(nodes)
+      else add_lint(node, id)
+      end
+    end
+
+    private
+
+    def add_lint(node, id)
+      record_lint(node, MESSAGE_FORMAT % id)
+    end
+
+    def add_lints_for_first_duplications(nodes)
+      nodes.each { |node| add_lint(node, node.tag_id) }
+    end
+
+    def id_map
+      @id_map ||= Hash.new { |hash, key| hash[key] = [] }
+    end
+  end
+end

--- a/spec/haml_lint/linter/repeated_id_spec.rb
+++ b/spec/haml_lint/linter/repeated_id_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe HamlLint::Linter::RepeatedId do
+  include_context 'linter'
+
+  context 'with no repeat ids' do
+    let(:haml) { '#don' }
+
+    it { should_not report_lint }
+  end
+
+  context 'with repeated ids' do
+    let(:haml) { "#don\n.no-id\n#don\n#don" }
+
+    it { should report_lint line: 1, severity: :error }
+    it { should report_lint line: 3, severity: :error }
+    it { should report_lint line: 4, severity: :error }
+  end
+end


### PR DESCRIPTION
This linter checks for the presence of the same `id` within the view.
Since this is an error according to the HTML spec, this linter has an
`error` severity level.

Closes #120