### PR TITLE
Add support for disabling linters with comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,75 @@ rational basis, we think that the opinions themselves are less important than
 the fact that `haml-lint` provides us with an automated and low-cost means of
 enforcing consistency.
 
+## Disabling Linters within Source Code
+
+One or more individual linters can be disabled locally in a file by adding
+a directive comment. These comments look like the following:
+
+```haml
+-# haml-lint:disable AltText, LineLength
+[...]
+-# haml-lint:enable AltText, LineLength
+```
+
+You can disable *all* linters for a section with the following:
+
+```haml
+-# haml-lint:disable all
+```
+
+### Directive Scope
+
+A directive will disable the given linters for the scope of the block. This
+scope is inherited by child elements and sibling elements that come after the
+comment. For example:
+
+```haml
+-# haml-lint:disable AltText
+#content
+  %img#will-not-show-lint-1{ src: "will-not-show-lint-1.png" }
+  -# haml-lint:enable AltText
+  %img#will-show-lint-1{ src: "will-show-lint-1.png" }
+  .sidebar
+    %img#will-show-lint-2{ src: "will-show-lint-2.png" }
+%img#will-not-show-lint-2{ src: "will-not-show-lint-2.png" }
+```
+
+The `#will-not-show-lint-1` image on line 2 will not raise an `AltText` lint
+because of the directive on line 1. Since that directive is at the top level of
+the tree, it applies everywhere.
+
+However, on line 4, the directive enables the `AltText` linter for the remainder
+of the `#content` element's content. This means that the `#will-show-lint-1`
+image on line 5 will raise an `AltText` lint because it is a sibling of the
+enabling directive that appears later in the `#content` element. Likewise, the
+`#will-show-lint-2` image on line 7 will raise an `AltText` lint because it is
+a child of a sibling of the enabling directive.
+
+Lastly, the `#will-not-show-lint-2` image on line 8 will not raise an `AltText`
+lint because the enabling directive on line 4 exists in a separate element and
+is not a sibling of the it.
+
+### Directive Precedence
+
+If there are multiple directives for the same linter in an element, the last
+directive wins. For example:
+
+```haml
+-# haml-lint:enable AltText
+%p Hello, world!
+-# haml-lint:disable AltText
+%img#will-not-show-lint{ src: "will-not-show-lint.png" }
+```
+
+There are two conflicting directives for the `AltText` linter. The first one
+enables it, but the second one disables it. Since the disable directive came
+later, the `#will-not-show-lint` element will not raise an `AltText` lint.
+
+You can use this functionality to selectively enable directives within a file by
+first using the `haml-lint:disable all` directive to disable all linters in the
+file, then selectively using `haml-lint:enable` to enable linters one at a time.
+
 ## Editor Integration
 
 ### Vim

--- a/lib/haml_lint/comment_configuration.rb
+++ b/lib/haml_lint/comment_configuration.rb
@@ -1,0 +1,39 @@
+module HamlLint
+  # Determines what linters are enabled or disabled via comments.
+  class CommentConfiguration
+    # Instantiates a new {HamlLint::CommentConfiguration}.
+    #
+    # @param node [HamlLint::Tree::Node] the node to configure
+    def initialize(node)
+      @directives = node.directives.reverse
+    end
+
+    # Checks whether a linter is disabled for the node.
+    #
+    # @api public
+    # @param linter_name [String] the name of the linter
+    # @return [true, false]
+    def disabled?(linter_name)
+      most_recent_disabled = directives_for(linter_name).map(&:disable?).first
+
+      most_recent_disabled || false
+    end
+
+    private
+
+    # The list of directives in order of precedence.
+    #
+    # @api private
+    # @return [Array<HamlLint::Directive>]
+    attr_reader :directives
+
+    # Finds all directives applicable to the given linter name.
+    #
+    # @api private
+    # @param linter_name [String] the name of the linter
+    # @return [Array<HamlLint::Directive>] the filtered directives
+    def directives_for(linter_name)
+      directives.select { |directive| (directive.linters & ['all', linter_name]).any? }
+    end
+  end
+end

--- a/lib/haml_lint/directive.rb
+++ b/lib/haml_lint/directive.rb
@@ -1,0 +1,128 @@
+module HamlLint
+  # Handles linter configuration transformation via Haml comments.
+  class Directive
+    LINTER_REGEXP = /(?:[A-Z]\w+)/
+
+    DIRECTIVE_REGEXP = /
+      # "haml-lint:" with optional spacing
+      \s*haml-lint\s*:\s*
+
+      # The mode - either disable or enable
+      (?<mode>(?:dis|en)able)\b\s*
+
+      # "all" or a comma-separated list (with optional spaces) of linters
+      (?<linters>all | (?:#{LINTER_REGEXP}\s*,\s*)* #{LINTER_REGEXP})
+    /x
+
+    # Constructs a directive from source code as a given line.
+    #
+    # @param source [String] the source code to analyze
+    # @param line [Integer] the line number the source starts at
+    # @return [HamlLint::Directive]
+    def self.from_line(source, line)
+      match = DIRECTIVE_REGEXP.match(source)
+
+      if match
+        new(source, line, match[:mode], match[:linters].split(/\s*,\s*/))
+      else
+        Null.new(source, line)
+      end
+    end
+
+    # Instantiates a new {HamlLint::Directive}
+    #
+    # @api semipublic
+    # @param source [String] the source code to analyze
+    # @param line [Integer] the line number the source starts at
+    # @param mode [String] the type of directive, one of "disable" or "enable"
+    # @param linters [Array<String>] the name of the linters to act upon
+    def initialize(source, line, mode, linters)
+      @source = source
+      @line = line
+      @mode = mode
+      @linters = linters
+    end
+
+    # The names of the linters to act upon.
+    #
+    # @return [String]
+    attr_reader :linters
+
+    # The mode of the directive. One of "disable" or "enable".
+    #
+    # @return [String]
+    attr_reader :mode
+
+    # Checks whether a directive is equivalent to another.
+    #
+    # @api public
+    # @param other [HamlLint::Directive] the other directive
+    # @return [true, false]
+    def ==(other)
+      super unless other.is_a?(HamlLint::Directive)
+
+      mode == other.mode && linters == other.linters
+    end
+
+    # Checks whether this is a disable directive.
+    #
+    # @return [true, false]
+    def disable?
+      mode == 'disable'
+    end
+
+    # Checks whether this is an enable directive.
+    #
+    # @return [true, false]
+    def enable?
+      mode == 'enable'
+    end
+
+    # Formats the directive for display in a console.
+    #
+    # @return [String]
+    def inspect
+      "#<HamlLint::Directive(mode=#{mode}, linters=#{linters})>"
+    end
+
+    # A null representation of a directive.
+    class Null < Directive
+      # Instantiates a new null directive.
+      #
+      # @param source [String] the source code to analyze
+      # @param line [Integer] the line number the source starts at
+      def initialize(source, line)
+        @source = source
+        @line = line
+      end
+
+      # Stubs out the disable check as false.
+      #
+      # @return [false]
+      def disable?
+        false
+      end
+
+      # Stubs out the ensable check as false.
+      #
+      # @return [false]
+      def enable?
+        false
+      end
+
+      # Formats the null directive for display in a console.
+      #
+      # @return [String]
+      def inspect
+        '#<HamlLint::Directive::Null>'
+      end
+
+      # Stubs out the linters.
+      #
+      # @return [Array]
+      def linters
+        []
+      end
+    end
+  end
+end

--- a/lib/haml_lint/haml_visitor.rb
+++ b/lib/haml_lint/haml_visitor.rb
@@ -14,14 +14,16 @@ module HamlLint
         visit_children(node) if descend == :children
       end
 
-      safe_send("visit_#{node_name(node)}", node, &block)
+      disabled = node.disabled?(self)
+
+      safe_send("visit_#{node_name(node)}", node, &block) unless disabled
 
       # Visit all children by default unless the block was invoked (indicating
       # the user intends to not recurse further, or wanted full control over
       # when the children were visited).
       visit_children(node) unless block_called
 
-      safe_send("after_visit_#{node_name(node)}", node, &block)
+      safe_send("after_visit_#{node_name(node)}", node, &block) unless disabled
     end
 
     def visit_children(parent)

--- a/lib/haml_lint/linter.rb
+++ b/lib/haml_lint/linter.rb
@@ -33,7 +33,7 @@ module HamlLint
     #
     # @return [String]
     def name
-      self.class.name.split('::').last
+      self.class.name.to_s.split('::').last
     end
 
     private

--- a/lib/haml_lint/linter/consecutive_comments.rb
+++ b/lib/haml_lint/linter/consecutive_comments.rb
@@ -5,14 +5,31 @@ module HamlLint
 
     COMMENT_DETECTOR = ->(child) { child.type == :haml_comment }
 
-    def visit_root(node)
+    def visit_haml_comment(node)
+      return if previously_reported?(node)
+
       HamlLint::Utils.for_consecutive_items(
-        node.children,
+        possible_group(node),
         COMMENT_DETECTOR,
       ) do |group|
+        group.each { |group_node| reported_nodes << group_node }
         record_lint(group.first,
                     "#{group.count} consecutive comments can be merged into one")
       end
+    end
+
+    private
+
+    def possible_group(node)
+      node.subsequents.unshift(node)
+    end
+
+    def previously_reported?(node)
+      reported_nodes.include?(node)
+    end
+
+    def reported_nodes
+      @reported_nodes ||= []
     end
   end
 end

--- a/lib/haml_lint/linter/consecutive_silent_scripts.rb
+++ b/lib/haml_lint/linter/consecutive_silent_scripts.rb
@@ -8,9 +8,11 @@ module HamlLint
       child.type == :silent_script && child.children.empty?
     end
 
-    def visit_root(node)
+    def visit_silent_script(node)
+      return if previously_reported?(node)
+
       HamlLint::Utils.for_consecutive_items(
-        node.children,
+        possible_group(node),
         SILENT_SCRIPT_DETECTOR,
         config['max_consecutive'] + 1,
       ) do |group|
@@ -18,6 +20,20 @@ module HamlLint
                     "#{group.count} consecutive Ruby scripts can be merged " \
                     'into a single `:ruby` filter')
       end
+    end
+
+    private
+
+    def possible_group(node)
+      node.subsequents.unshift(node)
+    end
+
+    def previously_reported?(node)
+      reported_nodes.include?(node)
+    end
+
+    def reported_nodes
+      @reported_nodes ||= []
     end
   end
 end

--- a/lib/haml_lint/linter/final_newline.rb
+++ b/lib/haml_lint/linter/final_newline.rb
@@ -3,19 +3,20 @@ module HamlLint
   class Linter::FinalNewline < Linter
     include LinterRegistry
 
-    def visit_root(_node)
+    def visit_root(root)
       return if document.source.empty?
 
-      dummy_node = Struct.new(:line).new(document.source_lines.count)
+      node = root.node_for_line(document.source_lines.count)
+      return if node.disabled?(self)
+
       ends_with_newline = document.source.end_with?("\n")
 
       if config['present']
         unless ends_with_newline
-          record_lint(dummy_node, 'Files should end with a trailing newline')
+          record_lint(node, 'Files should end with a trailing newline')
         end
       elsif ends_with_newline
-        record_lint(dummy_node,
-                    'Files should not end with a trailing newline')
+        record_lint(node, 'Files should not end with a trailing newline')
       end
     end
   end

--- a/lib/haml_lint/linter/indentation.rb
+++ b/lib/haml_lint/linter/indentation.rb
@@ -9,14 +9,16 @@ module HamlLint
       tab: /^\t*(?![ ])/,
     }.freeze
 
-    def visit_root(_node)
+    def visit_root(root)
       regex = INDENT_REGEX[config['character'].to_sym]
       dummy_node = Struct.new(:line)
 
       document.source_lines.each_with_index do |line, index|
         next if line =~ regex
 
-        record_lint dummy_node.new(index + 1), 'Line contains tabs in indentation'
+        unless root.node_for_line(index).disabled?(self)
+          record_lint dummy_node.new(index + 1), 'Line contains tabs in indentation'
+        end
       end
     end
   end

--- a/lib/haml_lint/linter/line_length.rb
+++ b/lib/haml_lint/linter/line_length.rb
@@ -7,14 +7,16 @@ module HamlLint
 
     MSG = 'Line is too long. [%d/%d]'.freeze
 
-    def visit_root(_node)
+    def visit_root(root)
       max_length = config['max']
-      dummy_node = Struct.new(:line)
 
       document.source_lines.each_with_index do |line, index|
         next if line.length <= max_length
 
-        record_lint(dummy_node.new(index + 1), format(MSG, line.length, max_length))
+        node = root.node_for_line(index + 1)
+        unless node.disabled?(self)
+          record_lint(node, format(MSG, line.length, max_length))
+        end
       end
     end
   end

--- a/lib/haml_lint/linter/trailing_whitespace.rb
+++ b/lib/haml_lint/linter/trailing_whitespace.rb
@@ -3,13 +3,14 @@ module HamlLint
   class Linter::TrailingWhitespace < Linter
     include LinterRegistry
 
-    def visit_root(_node)
-      dummy_node = Struct.new(:line)
-
+    def visit_root(root)
       document.source_lines.each_with_index do |line, index|
         next unless line =~ /\s+$/
 
-        record_lint dummy_node.new(index + 1), 'Line contains trailing whitespace'
+        node = root.node_for_line(index + 1)
+        unless node.disabled?(self)
+          record_lint node, 'Line contains trailing whitespace'
+        end
       end
     end
   end

--- a/lib/haml_lint/tree/haml_comment_node.rb
+++ b/lib/haml_lint/tree/haml_comment_node.rb
@@ -1,6 +1,14 @@
+require 'haml_lint/directive'
+
 module HamlLint::Tree
   # Represents a HAML comment node.
   class HamlCommentNode < Node
+    def directives
+      directives = super
+      directives << contained_directives
+      directives.flatten
+    end
+
     # Returns the full text content of this comment, including newlines if a
     # single comment spans multiple lines.
     #
@@ -13,6 +21,16 @@ module HamlLint::Tree
              .gsub(/^-#/, '')
              .gsub(/^  /, '')
              .rstrip
+    end
+
+    private
+
+    def contained_directives
+      text
+        .split("\n")
+        .each_with_index
+        .map { |source, offset| HamlLint::Directive.from_line(source, line + offset) }
+        .reject { |directive| directive.is_a?(HamlLint::Directive::Null) }
     end
   end
 end

--- a/lib/haml_lint/tree/node.rb
+++ b/lib/haml_lint/tree/node.rb
@@ -116,6 +116,13 @@ module HamlLint::Tree
       children.first || successor
     end
 
+    # The sibling nodes that come after this node in the tree.
+    #
+    # @return [Array<HamlLint::Tree::Node>]
+    def subsequents
+      siblings.subsequents(self)
+    end
+
     # Returns the text content of this node.
     #
     # @return [String]

--- a/lib/haml_lint/tree/node.rb
+++ b/lib/haml_lint/tree/node.rb
@@ -1,3 +1,5 @@
+require 'haml_lint/comment_configuration'
+
 module HamlLint::Tree
   # Decorator class that provides a convenient set of helpers for HAML's
   # {Haml::Parser::ParseNode} struct.
@@ -9,6 +11,8 @@ module HamlLint::Tree
   #
   # @abstract
   class Node
+    include Enumerable
+
     attr_accessor :children, :parent
     attr_reader :line, :type
 
@@ -23,24 +27,42 @@ module HamlLint::Tree
       @type = parse_node.type
     end
 
-    # Returns the first node found under the subtree which matches the given
-    # block.
+    # Holds any configuration that is created from Haml comments.
     #
-    # Returns nil if no node matching the given block was found.
-    #
-    # @yieldparam [HamlLint::Tree::Node] node
-    # @yieldreturn [Boolean] whether the node matches
-    # @return [HamlLint::Tree::Node,nil]
-    def find(&block)
-      return self if yield(self)
+    # @return [HamlLint::CommentConfiguration]
+    def comment_configuration
+      @comment_configuration ||= HamlLint::CommentConfiguration.new(self)
+    end
 
-      children.each do |child|
-        if result = child.find(&block)
-          return result
-        end
+    # Checks whether a visitor is disabled due to comment configuration.
+    #
+    # @param [HamlLint::HamlVisitor]
+    # @return [true, false]
+    def disabled?(visitor)
+      visitor.is_a?(HamlLint::Linter) &&
+        comment_configuration.disabled?(visitor.name)
+    end
+
+    # Implements the Enumerable interface to walk through an entire tree.
+    #
+    # @return [Enumerator, HamlLint::Tree::Node]
+    def each
+      return to_enum(__callee__) unless block_given?
+
+      node = self
+      loop do
+        yield node
+        break unless (node = node.next_node)
       end
+    end
 
-      nil # Otherwise no matching node was found
+    # The comment directives to apply to the node.
+    #
+    # @return [Array<HamlLint::Directive>]
+    def directives
+      directives = []
+      directives << predecessor.directives if predecessor
+      directives.flatten
     end
 
     # Source code of all lines this node spans (excluding children).
@@ -63,6 +85,13 @@ module HamlLint::Tree
       "#<#{self.class.name}>"
     end
 
+    # The previous node to be traversed in the tree.
+    #
+    # @return [HamlLint::Tree::Node, nil]
+    def predecessor
+      siblings.previous(self) || parent
+    end
+
     # Returns the node that follows this node, whether it be a sibling or an
     # ancestor's child, but not a child of this node.
     #
@@ -72,9 +101,7 @@ module HamlLint::Tree
     #
     # @return [HamlLint::Tree::Node,nil]
     def successor
-      siblings = parent ? parent.children : [self]
-
-      next_sibling = siblings[siblings.index(self) + 1] if siblings.count > 1
+      next_sibling = siblings.next(self)
       return next_sibling if next_sibling
 
       parent.successor if parent
@@ -94,6 +121,72 @@ module HamlLint::Tree
     # @return [String]
     def text
       @value[:text].to_s
+    end
+
+    private
+
+    # The siblings of this node within the tree.
+    #
+    # @api private
+    # @return [Array<HamlLint::Tree::Node>]
+    def siblings
+      @siblings ||= Siblings.new(parent ? parent.children : [self])
+    end
+
+    # Finds the node's siblings within the tree and makes them queryable.
+    class Siblings < SimpleDelegator
+      # Finds the next sibling in the tree for a given node.
+      #
+      # @param node [HamlLint::Tree::Node]
+      # @return [HamlLint::Tree::Node, nil]
+      def next(node)
+        subsequents(node).first
+      end
+
+      # Finds the previous sibling in the tree for a given node.
+      #
+      # @param node [HamlLint::Tree::Node]
+      # @return [HamlLint::Tree::Node, nil]
+      def previous(node)
+        priors(node).last
+      end
+
+      # Finds all sibling notes that appear before a node in the tree.
+      #
+      # @param node [HamlLint::Tree::Node]
+      # @return [Array<HamlLint::Tree::Node>]
+      def priors(node)
+        position = position(node)
+        if position.zero?
+          []
+        else
+          siblings[0..(position - 1)]
+        end
+      end
+
+      # Finds all sibling notes that appear after a node in the tree.
+      #
+      # @param node [HamlLint::Tree::Node]
+      # @return [Array<HamlLint::Tree::Node>]
+      def subsequents(node)
+        siblings[(position(node) + 1)..-1]
+      end
+
+      private
+
+      # The set of siblings within the tree.
+      #
+      # @api private
+      # @return [Array<HamlLint::Tree::Node>]
+      alias siblings __getobj__
+
+      # Finds the position of a node within a set of siblings.
+      #
+      # @api private
+      # @return [Integer, nil]
+      def position(node)
+        siblings.index(node)
+      end
     end
   end
 end

--- a/lib/haml_lint/tree/null_node.rb
+++ b/lib/haml_lint/tree/null_node.rb
@@ -1,0 +1,15 @@
+module HamlLint::Tree
+  # A null object version of a node that can be used as a safe default.
+  class NullNode < Node
+    # Instantiates a new {HamlLint::Tree::NullNode}, ignoring all input.
+    def initialize(*_args); end
+
+    # Overrides the disabled check to always say the linter is enabled.
+    #
+    # @param _linter [HamlLint::Linter] the linter to check
+    # @return [false]
+    def disabled?(_linter)
+      false
+    end
+  end
+end

--- a/lib/haml_lint/tree/root_node.rb
+++ b/lib/haml_lint/tree/root_node.rb
@@ -1,3 +1,5 @@
+require 'haml_lint/tree/null_node'
+
 module HamlLint::Tree
   # Represents the root node of a HAML document that contains all other nodes.
   class RootNode < Node
@@ -6,6 +8,14 @@ module HamlLint::Tree
     # @return [String] a file name
     def file
       @document.file
+    end
+
+    # Gets the node of the syntax tree for a given line number.
+    #
+    # @param line [Integer] the line number of the node
+    # @return [HamlLint::Node]
+    def node_for_line(line)
+      find(HamlLint::Tree::NullNode) { |node| node.line == line }
     end
   end
 end

--- a/spec/haml_lint/comment_configuration_spec.rb
+++ b/spec/haml_lint/comment_configuration_spec.rb
@@ -1,0 +1,162 @@
+require 'spec_helper'
+
+RSpec.describe HamlLint::CommentConfiguration do
+  subject(:config) { described_class.new(node) }
+
+  context 'for a node with no directives' do
+    let(:node) { double('node', directives: []) }
+
+    describe '#disabled?' do
+      subject { config.disabled?('all') }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  context 'for a node with directives' do
+    let(:config) { double('config') }
+    let(:document) { HamlLint::Document.new(source, options) }
+    let(:options) { { config: { 'skip_frontmatter' => true } } }
+    let(:source) do
+      [
+        '-#',
+        '  haml-lint:disable AltText',
+        '  haml-lint:disable LineLength',
+        '%img{ src: "test-no-lint.png" }',
+        '%div',
+        '  %img{ src: "test-no-lint-2.png" }',
+        '-# haml-lint:enable AltText',
+        '%img{ src: "test-lint.png" }',
+        '%div',
+        '  -# haml-lint:disable AltText',
+        '  %img{src: "test-no-lint-3.png"}',
+        '%img{src: "test-lint-2.png"}'
+      ].join("\n")
+    end
+
+    describe '#disabled?' do
+      subject { document.tree.select { |node| node.disabled?(linter) }.map(&:line) }
+
+      context 'for the AltText linter' do
+        let(:linter) { HamlLint::Linter::AltText.new(config) }
+
+        it 'is disabled for the image tags for test-no-lint sources' do
+          test_no_lint = document.tree.select do |node|
+            node.type == :tag && node.source_code =~ /test-no-lint/
+          end
+
+          expect(test_no_lint.all? { |node| node.disabled?(linter) }).to eq(true)
+        end
+
+        it 'is not disabled for the image tags for test-lint sources' do
+          test_lint = document.tree.select do |node|
+            node.type == :tag && node.source_code =~ /test-lint/
+          end
+
+          expect(test_lint.none? { |node| node.disabled?(linter) }).to eq(true)
+        end
+      end
+
+      context 'for the LineLength linter' do
+        let(:linter) { HamlLint::Linter::LineLength.new(config) }
+
+        it 'is disabled for every node except the root in the tree' do
+          root_disabled = document.tree.disabled?(linter)
+          all_others_disabled = document.tree.children.all? { |node| node.disabled?(linter) }
+
+          expect(root_disabled).to eq(false)
+          expect(all_others_disabled).to eq(true)
+        end
+      end
+    end
+  end
+
+  context 'for a node that has an "all" directive' do
+    let(:config) { double('config') }
+    let(:document) { HamlLint::Document.new(source, options) }
+    let(:options) { { config: { 'skip_frontmatter' => true } } }
+
+    context 'that is being overridden' do
+      let(:source) do
+        [
+          '-# haml-lint:disable all',
+          '%img{ src: "test-no-lint.png" }',
+          '%div',
+          '  %img{ src: "test-no-lint-2.png" }',
+          '-# haml-lint:enable AltText',
+          '%img{ src: "test-lint.png" }',
+          '%div',
+          '  -# haml-lint:disable AltText',
+          '  %img{src: "test-no-lint-3.png"}',
+          '%img{src: "test-lint-2.png"}'
+        ].join("\n")
+      end
+
+      describe '#disabled?' do
+        subject { document.tree.select { |node| node.disabled?(linter) }.map(&:line) }
+
+        context 'for the AltText linter' do
+          let(:linter) { HamlLint::Linter::AltText.new(config) }
+
+          it 'is disabled for the image tags for test-no-lint sources' do
+            test_no_lint = document.tree.select do |node|
+              node.type == :tag && node.source_code =~ /test-no-lint/
+            end
+
+            expect(test_no_lint.all? { |node| node.disabled?(linter) }).to eq(true)
+          end
+
+          it 'is not disabled for the image tags for test-lint sources' do
+            test_lint = document.tree.select do |node|
+              node.type == :tag && node.source_code =~ /test-lint/
+            end
+
+            expect(test_lint.none? { |node| node.disabled?(linter) }).to eq(true)
+          end
+        end
+      end
+    end
+
+    context 'that is overriding other directives' do
+      let(:source) do
+        [
+          '-# haml-lint:disable AltText',
+          '%img{ src: "test-no-lint.png" }',
+          '%div',
+          '  %img{ src: "test-no-lint-2.png" }',
+          '-# haml-lint:enable all',
+          '%img{ src: "test-lint.png" }',
+          '-# haml-lint:enable AltText',
+          '%div',
+          '  -# haml-lint:disable all',
+          '  %img{src: "test-no-lint-3.png"}',
+          '%img{src: "test-lint-2.png"}'
+        ].join("\n")
+      end
+
+      describe '#disabled?' do
+        subject { document.tree.select { |node| node.disabled?(linter) }.map(&:line) }
+
+        context 'for the AltText linter' do
+          let(:linter) { HamlLint::Linter::AltText.new(config) }
+
+          it 'is disabled for the image tags for test-no-lint sources' do
+            test_no_lint = document.tree.select do |node|
+              node.type == :tag && node.source_code =~ /test-no-lint/
+            end
+
+            expect(test_no_lint.all? { |node| node.disabled?(linter) }).to eq(true)
+          end
+
+          it 'is not disabled for the image tags for test-lint sources' do
+            test_lint = document.tree.select do |node|
+              node.type == :tag && node.source_code =~ /test-lint/
+            end
+
+            expect(test_lint.none? { |node| node.disabled?(linter) }).to eq(true)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/haml_lint/directive_spec.rb
+++ b/spec/haml_lint/directive_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+RSpec.describe HamlLint::Directive do
+  subject(:directive) { described_class.new }
+
+  describe '.from_line' do
+    let(:line) { 1 }
+
+    subject(:directive) { described_class.from_line(source, line) }
+
+    context 'for a line that is a directive' do
+      let(:source) { ' haml-lint:disable AltText, LineLength' }
+
+      describe '#disable?' do
+        subject { directive.disable? }
+
+        it { is_expected.to eq(true) }
+      end
+
+      describe '#enable?' do
+        subject { directive.enable? }
+
+        it { is_expected.to eq(false) }
+      end
+
+      describe '#linters' do
+        subject { directive.linters }
+
+        it { is_expected.to eq(%w[AltText LineLength]) }
+      end
+
+      describe '#inspect' do
+        subject { directive.inspect }
+
+        it { is_expected.to match(/mode=disable, linters=\["AltText", "LineLength"\]/) }
+      end
+    end
+
+    context 'for a line that is not a directive' do
+      let(:source) { 'Disable these linters' }
+
+      describe '#disable?' do
+        subject { directive.disable? }
+
+        it { is_expected.to eq(false) }
+      end
+
+      describe '#enable?' do
+        subject { directive.enable? }
+
+        it { is_expected.to eq(false) }
+      end
+
+      describe '#linters' do
+        subject { directive.linters }
+
+        it { is_expected.to eq([]) }
+      end
+
+      describe '#inspect' do
+        subject { directive.inspect }
+
+        it { is_expected.to eq('#<HamlLint::Directive::Null>') }
+      end
+    end
+  end
+end

--- a/spec/haml_lint/haml_visitor_spec.rb
+++ b/spec/haml_lint/haml_visitor_spec.rb
@@ -222,5 +222,30 @@ describe HamlLint::HamlVisitor do
         end
       end
     end
+
+    context 'when a node disables the visitor' do
+      class DisabledVisitor < TrackingVisitor
+        def visit_child(node)
+          @node_order << node.type
+        end
+
+        def visit_root(node)
+          @node_order << node.type
+        end
+      end
+
+      let(:child_node) { double('child', children: [], disabled?: false, type: :child) }
+      let(:document) { double('document', tree: node) }
+      let(:node) { double('node', children: [child_node], disabled?: true, type: :root) }
+      let(:visitor) { DisabledVisitor.new }
+
+      it 'does not visit the node' do
+        visitor.node_order.should_not include(:root)
+      end
+
+      it 'visits the child node' do
+        visitor.node_order.should include(:child)
+      end
+    end
   end
 end

--- a/spec/haml_lint/linter/consecutive_comments_spec.rb
+++ b/spec/haml_lint/linter/consecutive_comments_spec.rb
@@ -29,5 +29,11 @@ describe HamlLint::Linter::ConsecutiveComments do
     it { should report_lint line: 1 }
     it { should_not report_lint line: 6 }
     it { should report_lint line: 8 }
+
+    context 'but the linter is disabled in the file' do
+      let(:haml) { "-# haml-lint:disable ConsecutiveComments\n" + super() }
+
+      it { should_not report_lint }
+    end
   end
 end

--- a/spec/haml_lint/linter/consecutive_silent_scripts_spec.rb
+++ b/spec/haml_lint/linter/consecutive_silent_scripts_spec.rb
@@ -23,6 +23,12 @@ describe HamlLint::Linter::ConsecutiveSilentScripts do
       it { should_not report_lint line: 2 }
       it { should_not report_lint line: 3 }
 
+      context 'but the linter is disabled in the file' do
+        let(:haml) { "-# haml-lint:disable ConsecutiveSilentScripts\n" + super() }
+
+        it { should_not report_lint }
+      end
+
       context 'and they contain nested content that results in output' do
         let(:haml) { <<-HAML }
           - if expression
@@ -47,5 +53,11 @@ describe HamlLint::Linter::ConsecutiveSilentScripts do
 
     it { should_not report_lint line: 1 }
     it { should report_lint line: 5 }
+
+    context 'but the linter is disabled in the file' do
+      let(:haml) { "-# haml-lint:disable ConsecutiveSilentScripts\n" + super() }
+
+      it { should_not report_lint }
+    end
   end
 end

--- a/spec/haml_lint/linter/final_newline_spec.rb
+++ b/spec/haml_lint/linter/final_newline_spec.rb
@@ -22,6 +22,12 @@ describe HamlLint::Linter::FinalNewline do
       let(:haml) { '%span' }
 
       it { should report_lint line: 1 }
+
+      context 'but the linter is disabled in the file' do
+        let(:haml) { "-# haml-lint:disable FinalNewline\n" + super() }
+
+        it { should_not report_lint }
+      end
     end
   end
 
@@ -38,6 +44,12 @@ describe HamlLint::Linter::FinalNewline do
       let(:haml) { "%span\n" }
 
       it { should report_lint line: 1 }
+
+      context 'but the linter is disabled in the file' do
+        let(:haml) { "-# haml-lint:disable FinalNewline\n" + super() }
+
+        it { should_not report_lint }
+      end
     end
 
     context 'when the file does not end with a newline' do

--- a/spec/haml_lint/linter/indentation_spec.rb
+++ b/spec/haml_lint/linter/indentation_spec.rb
@@ -19,12 +19,15 @@ describe HamlLint::Linter::Indentation do
   end
 
   context 'when line contains only tabs for indentation' do
-    let(:haml) { <<-HAML }
-      %span
-      \tHello
-    HAML
+    let(:haml) { "%span\n\tHello" }
 
     it { should report_lint line: 2 }
+
+    context 'but the linter is disabled in the file' do
+      let(:haml) { "-# haml-lint:disable Indentation\n" + super() }
+
+      it { should_not report_lint }
+    end
   end
 
   context 'when line contains tabs that are not indentation' do
@@ -43,12 +46,15 @@ describe HamlLint::Linter::Indentation do
     end
 
     context 'when line contains spaces for indentation' do
-      let(:haml) { <<-HAML }
-        %span
-          Hello
-      HAML
+      let(:haml) { "%span\n  Hello" }
 
       it { should report_lint line: 2 }
+
+      context 'but the linter is disabled in the file' do
+        let(:haml) { "-# haml-lint:disable Indentation\n" + super() }
+
+        it { should_not report_lint }
+      end
     end
 
     context 'when line contains only tabs for indentation' do

--- a/spec/haml_lint/linter/line_length_spec.rb
+++ b/spec/haml_lint/linter/line_length_spec.rb
@@ -4,15 +4,23 @@ describe HamlLint::Linter::LineLength do
   include_context 'linter'
 
   context 'when a file contains lines which are too long' do
-    let(:haml) { <<-HAML }
-      %p
-        = link_to 'Foobar', i_need_to_make_this_line_longer_path, class: 'button alert'
-        This line should be short
-    HAML
+    let(:haml) do
+      [
+        '%p',
+        '  = link_to "Foobar", i_need_to_make_this_line_longer_path, class: "button alert"',
+        '  This line should be short'
+      ].join("\n")
+    end
 
     it { should_not report_lint line: 1 }
     it { should report_lint line: 2 }
     it { should_not report_lint line: 3 }
+
+    context 'but the linter is disabled in the file' do
+      let(:haml) { "-# haml-lint:disable LineLength\n" + super() }
+
+      it { should_not report_lint }
+    end
   end
 
   context 'when a file does not contain lines which are too long' do

--- a/spec/haml_lint/linter/trailing_whitespace_spec.rb
+++ b/spec/haml_lint/linter/trailing_whitespace_spec.rb
@@ -7,12 +7,24 @@ describe HamlLint::Linter::TrailingWhitespace do
     let(:haml) { '- some_code_with_trailing_whitespace      ' }
 
     it { should report_lint line: 1 }
+
+    context 'but the linter is disabled in the file' do
+      let(:haml) { "-# haml-lint:disable TrailingWhitespace\n" + super() }
+
+      it { should_not report_lint }
+    end
   end
 
   context 'when line contains trailing tabs' do
     let(:haml) { "- some_code_with_trailing_whitespace\t" }
 
     it { should report_lint line: 1 }
+
+    context 'but the linter is disabled in the file' do
+      let(:haml) { "-# haml-lint:disable TrailingWhitespace\n" + super() }
+
+      it { should_not report_lint }
+    end
   end
 
   context 'when line contains trailing newline' do

--- a/spec/haml_lint/tree/haml_comment_node_spec.rb
+++ b/spec/haml_lint/tree/haml_comment_node_spec.rb
@@ -8,7 +8,70 @@ describe HamlLint::Tree::HamlCommentNode do
   end
 
   let(:document) { HamlLint::Document.new(normalize_indent(haml), options) }
-  subject { document.tree.find { |node| node.type == :haml_comment } }
+  let(:node) { document.tree.find { |node| node.type == :haml_comment } }
+
+  subject { node }
+
+  describe '#directives' do
+    subject { super().directives }
+
+    context 'when there are no directives' do
+      let(:haml) { '-# A comment' }
+
+      it { should == [] }
+    end
+
+    context 'when there are directives in the node' do
+      let(:haml) { '-# haml-lint:disable AltText' }
+
+      it { should eq([HamlLint::Directive.new(haml, 1, 'disable', %w[AltText])]) }
+
+      context 'with bad formatting' do
+        let(:haml) { '-#haml-lint  :disable AltText' }
+
+        it { should eq([HamlLint::Directive.new(haml, 1, 'disable', %w[AltText])]) }
+      end
+    end
+
+    context 'when there are directives from a parent' do
+      let(:haml) { lines.join("\n") }
+      let(:lines) do
+        [
+          '-# haml-lint:disable AltText',
+          '-# haml-lint:enable LineLength'
+        ]
+      end
+      let(:node) { document.tree.select { |node| node.type == :haml_comment }.last }
+
+      let(:expectation) do
+        [
+          HamlLint::Directive.new(lines.first, 1, 'disable', %w[AltText]),
+          HamlLint::Directive.new(lines.last, 2, 'enable', %w[LineLength])
+        ]
+      end
+
+      it { should eq(expectation) }
+    end
+
+    context 'when there are directives outside the scope of a node' do
+      let(:haml) { lines.join("\n") }
+      let(:lines) do
+        [
+          '-# haml-lint:disable AltText',
+          '%div',
+          '  #haml-lint:disable AlignmentTabs',
+          '-# haml-lint:enable LineLength'
+        ]
+      end
+      let(:node) { document.tree.select { |node| node.type == :haml_comment }.last }
+
+      let(:out_of_scope) do
+        HamlLint::Directive.new(lines[2], 3, 'disable', %w[AlignmentTabs])
+      end
+
+      it { should_not include(out_of_scope) }
+    end
+  end
 
   describe '#text' do
     subject { super().text }


### PR DESCRIPTION
When you are first introducing a linting system to a code base that
hasn't not previously used one, it can be a painful experience due to
the linter raising too many problems out of the gate. By enabling
linters to be selectively toggled off within a file, we can give our
users a way to gradually introduce linting into their code base.

This feature allows you do place a Haml comment within a file to toggle
a set of linters for a block. For example, adding this comment to the
top of a Haml file:

```haml
-# haml-lint:disable all
```

will disable all of the Haml-Lint linters for the remainder of the file,
unless later enabled with a similar comment in the file, like so:

```haml
-# haml-lint:enable AltText
```

The comment line can be either the string "all" or a comma-separated
list of linter names. They will be subsequently disabled or enabled
based on the comment. In the event of conflicting directives for
a linter, the last one wins.

Closes #87