### PR TITLE
Ensure the JSON reporter is listed in the CLI

### DIFF
--- a/lib/haml_lint/cli.rb
+++ b/lib/haml_lint/cli.rb
@@ -111,11 +111,7 @@ module HamlLint
     def print_available_reporters
       log.info 'Available reporters:'
 
-      reporter_names = HamlLint::Reporter.descendants.map do |reporter|
-        reporter.name.split('::').last.sub(/Reporter$/, '').downcase
-      end
-
-      reporter_names.sort.each do |reporter_name|
+      HamlLint::Reporter.available.map(&:cli_name).sort.each do |reporter_name|
         log.log " - #{reporter_name}"
       end
     end

--- a/lib/haml_lint/options.rb
+++ b/lib/haml_lint/options.rb
@@ -14,6 +14,7 @@ module HamlLint
         parser.banner = "Usage: #{APP_NAME} [options] [file1, file2, ...]"
 
         add_linter_options parser
+        add_report_options parser
         add_file_options parser
         add_logger_options parser
         add_info_options parser
@@ -41,9 +42,13 @@ module HamlLint
                 "Specify which linters you don't want to run") do |linters|
         @options[:excluded_linters] = linters
       end
+    end
 
+    def add_report_options(parser)
+      reporters = HamlLint::Reporter.available.map(&:cli_name).sort
       parser.on('-r', '--reporter reporter', String,
-                'Specify which reporter you want to use to generate the output') do |reporter|
+                'Specify which reporter you want to use to generate the output. One of:',
+                *reporters.map { |name| "  - #{name}" }) do |reporter|
         @options[:reporter] = load_reporter_class(reporter.capitalize)
       end
 

--- a/lib/haml_lint/reporter.rb
+++ b/lib/haml_lint/reporter.rb
@@ -8,6 +8,31 @@ module HamlLint
   class Reporter
     include Reporter::Hooks
 
+    # The CLI names of all configured reporters.
+    #
+    # @return [Array<String>]
+    def self.available
+      descendants.flat_map do |reporter|
+        available = reporter.available
+        available.unshift(reporter) if reporter.available?
+        available
+      end
+    end
+
+    # A flag for whether to show the reporter on the command line.
+    #
+    # @return [Boolean]
+    def self.available?
+      true
+    end
+
+    # The name of the reporter as passed from the CLI.
+    #
+    # @return [String]
+    def self.cli_name
+      name.split('::').last.sub(/Reporter$/, '').downcase
+    end
+
     # Creates the reporter that will display the given report.
     #
     # @param logger [HamlLint::Logger]

--- a/lib/haml_lint/reporter/hash_reporter.rb
+++ b/lib/haml_lint/reporter/hash_reporter.rb
@@ -1,6 +1,13 @@
 module HamlLint
   # Outputs report as a Ruby Hash for easy use by other tools.
   class Reporter::HashReporter < Reporter
+    # Disables this reporter on the CLI since it doesn't output anything.
+    #
+    # @return [false]
+    def self.available?
+      false
+    end
+
     def display_report(report)
       lints = report.lints
       grouped = lints.group_by(&:filename)

--- a/lib/haml_lint/reporter/json_reporter.rb
+++ b/lib/haml_lint/reporter/json_reporter.rb
@@ -1,6 +1,13 @@
 module HamlLint
   # Outputs report as a JSON document.
   class Reporter::JsonReporter < Reporter::HashReporter
+    # Ensures that the CLI is able to use the the reporter.
+    #
+    # @return [true]
+    def self.available?
+      true
+    end
+
     def display_report(report)
       log.log super.to_json
     end

--- a/lib/haml_lint/reporter/json_reporter.rb
+++ b/lib/haml_lint/reporter/json_reporter.rb
@@ -1,3 +1,5 @@
+require 'haml_lint/reporter/hash_reporter'
+
 module HamlLint
   # Outputs report as a JSON document.
   class Reporter::JsonReporter < Reporter::HashReporter

--- a/spec/haml_lint/cli_spec.rb
+++ b/spec/haml_lint/cli_spec.rb
@@ -117,6 +117,7 @@ describe HamlLint::CLI do
       it 'displays the available reporters' do
         subject
         output.should include 'default'
+        output.should include 'json'
       end
 
       it { should == Sysexits::EX_OK }


### PR DESCRIPTION
Since the `HashReporter` was extracted from the old `JsonReporter` and
the `JsonReporter` made to subclass it, the reporter wasn't showing up
as an option on the command line. By changing how we look up the
reporters that are available, we can ensure that we walk through all the
descendants and list all of the reporters that should be available to
the CLI.

Fixes #186