### PR TITLE
Fix defaulting to NullNode in RootNode#node_for_line

### DIFF
--- a/lib/haml_lint/tree/root_node.rb
+++ b/lib/haml_lint/tree/root_node.rb
@@ -15,7 +15,7 @@ module HamlLint::Tree
     # @param line [Integer] the line number of the node
     # @return [HamlLint::Node]
     def node_for_line(line)
-      find(HamlLint::Tree::NullNode) { |node| node.line == line }
+      find(lambda { HamlLint::Tree::NullNode.new }) { |node| node.line == line }
     end
   end
 end


### PR DESCRIPTION
I don't have a lot of context on this but of code, other than it was
added in 4c95e3b5 to allow nodes to be disableable via comments.

When running haml-lint on a local project, I ran into the same issue as
was described in #186:

```
  undefined method `call' for HamlLint::Tree::NullNode:Class
  /Users/henrictrotzig/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/haml_lint-0.22.1/lib/haml_lint/tree/root_node.rb:18:in
  `find'
```

Making the first argument to `find` a lambda (or a proc) fixed the
issue.

Fixes #186