### PR TITLE
Keep empty lines within Ruby filters

### DIFF
--- a/lib/haml_lint/ruby_extractor.rb
+++ b/lib/haml_lint/ruby_extractor.rb
@@ -125,7 +125,7 @@ module HamlLint
     def visit_filter(node) # rubocop:disable Metrics/AbcSize
       if node.filter_type == 'ruby'
         node.text.split("\n").each_with_index do |line, index|
-          add_line(line, node.line + index + 1)
+          add_line(line, node.line + index + 1, false)
         end
       else
         add_dummy_puts(node, ":#{node.filter_type}")
@@ -158,8 +158,8 @@ module HamlLint
       @output_count += 1
     end
 
-    def add_line(code, node_or_line)
-      return if code.empty?
+    def add_line(code, node_or_line, discard_blanks = true)
+      return if code.empty? && discard_blanks
 
       indent_level = @indent_level
 

--- a/spec/haml_lint/ruby_extractor_spec.rb
+++ b/spec/haml_lint/ruby_extractor_spec.rb
@@ -464,6 +464,29 @@ describe HamlLint::RubyExtractor do
       end
     end
 
+    context 'with a Ruby filter containing block keywords' do
+      let(:haml) { <<-HAML }
+        :ruby
+          def foo
+            42
+          end
+
+          def bar
+            23
+          end
+      HAML
+
+      its(:source) { should == normalize_indent(<<-RUBY).rstrip }
+        def foo
+          42
+        end
+
+        def bar
+          23
+        end
+      RUBY
+    end
+
     context 'with a filter with interpolated values' do
       let(:haml) { <<-HAML }
         :filter


### PR DESCRIPTION
Because there are RuboCop rules that deal with spacing between blocks,
we need to retain empty lines within Ruby filters. Since Ruby filters
should be interpreted as pure Ruby, this does not change the semantics
of the output and allows us to use more of the cops without raising
false positives.

Closes #189