### PR TITLE
Ensure RepeatedId linter resets between files

### DIFF
--- a/lib/haml_lint/linter/repeated_id.rb
+++ b/lib/haml_lint/linter/repeated_id.rb
@@ -5,6 +5,10 @@ module HamlLint
 
     MESSAGE_FORMAT = %{Do not repeat id "#%s" on the page}.freeze
 
+    def visit_root(_node)
+      @id_map = Hash.new { |hash, key| hash[key] = [] }
+    end
+
     def visit_tag(node)
       id = node.tag_id
       return unless id && !id.empty?
@@ -19,16 +23,14 @@ module HamlLint
 
     private
 
+    attr_reader :id_map
+
     def add_lint(node, id)
       record_lint(node, MESSAGE_FORMAT % id)
     end
 
     def add_lints_for_first_duplications(nodes)
       nodes.each { |node| add_lint(node, node.tag_id) }
-    end
-
-    def id_map
-      @id_map ||= Hash.new { |hash, key| hash[key] = [] }
     end
   end
 end

--- a/spec/haml_lint/linter/repeated_id_spec.rb
+++ b/spec/haml_lint/linter/repeated_id_spec.rb
@@ -16,4 +16,16 @@ RSpec.describe HamlLint::Linter::RepeatedId do
     it { should report_lint line: 3, severity: :error }
     it { should report_lint line: 4, severity: :error }
   end
+
+  context 'with repeated ids across files' do
+    let(:haml) { '#don' }
+
+    it 'should not report when run on two separate files' do
+      second_document = HamlLint::Document.new(normalize_indent(haml), options)
+
+      subject.run(second_document)
+
+      subject.should_not report_lint
+    end
+  end
 end


### PR DESCRIPTION
When I originally wrote the RepeatedId linter, I was expecting that the
linter was re-instantiated for each file. This assumption was incorrect!
That lead the linter to report repeated element IDs across different
files - a condition that normally happens in an app and does not
indicate a failure.

This fixes the issue and ensures we reset the state between different
files.

Closes #193