### PR TITLE
Handle different line endings in files

### DIFF
--- a/lib/haml_lint/document.rb
+++ b/lib/haml_lint/document.rb
@@ -43,7 +43,7 @@ module HamlLint
     def process_source(source)
       @source = process_encoding(source)
       @source = strip_frontmatter(source)
-      @source_lines = @source.split("\n")
+      @source_lines = @source.split(/\r\n|\r|\n/)
 
       @tree = process_tree(HamlLint::Adapter.detect_class.new(@source).parse)
     rescue Haml::Error => ex

--- a/spec/haml_lint/document_spec.rb
+++ b/spec/haml_lint/document_spec.rb
@@ -97,5 +97,23 @@ describe HamlLint::Document do
         expect { subject }.to_not raise_error
       end
     end
+
+    context 'when given a file with different line endings' do
+      context 'that are just carriage returns' do
+        let(:source) { "%div\r  %p\r    Hello, world" }
+
+        it 'interprets the line endings as newlines, like Haml' do
+          expect { subject }.to_not raise_error
+        end
+      end
+
+      context 'that are Windows-style CRLF' do
+        let(:source) { "%div\r\n  %p\r\n    Hello, world" }
+
+        it 'interprets the line endings as newlines, like Haml' do
+          expect { subject }.to_not raise_error
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Haml takes a relaxed approach to handling line endings in source files
[see this line][1]. However, we are currently only splitting via the
newline character, which causes a crash when we encounter a file that
has `\r` line endings. Since Haml parses that file properly, we should
to.

There are two types of error that can occur, depending on how the file
is structured.

First, the source code of a node can raise an error because the split
fails:

```
undefined method `join' for nil:NilClass (NoMethodError)
lib/haml_lint/tree/node.rb:80:in `source_code'
lib/haml_lint/tree/tag_node.rb:91:in `attributes_source'
lib/haml_lint/tree/tag_node.rb:65:in `static_attributes_source'
lib/haml_lint/linter/classes_before_ids.rb:16:in `visit_tag'
lib/haml_lint/haml_visitor.rb:40:in `safe_send'
lib/haml_lint/haml_visitor.rb:19:in `visit'
lib/haml_lint/haml_visitor.rb:30:in `block in visit_children'
lib/haml_lint/haml_visitor.rb:30:in `each'
lib/haml_lint/haml_visitor.rb:30:in `visit_children'
lib/haml_lint/haml_visitor.rb:24:in `visit'
lib/haml_lint/haml_visitor.rb:30:in `block in visit_children'
lib/haml_lint/haml_visitor.rb:30:in `each'
lib/haml_lint/haml_visitor.rb:30:in `visit_children'
lib/haml_lint/haml_visitor.rb:24:in `visit'
lib/haml_lint/linter.rb:28:in `run'
lib/haml_lint/runner.rb:84:in `block in collect_lints'
lib/haml_lint/runner.rb:83:in `map'
lib/haml_lint/runner.rb:83:in `collect_lints'
lib/haml_lint/runner.rb:119:in `process_file'
lib/haml_lint/runner.rb:108:in `block in process_files'
lib/haml_lint/runner.rb:107:in `each'
lib/haml_lint/runner.rb:107:in `process_files'
lib/haml_lint/runner.rb:132:in `report'
lib/haml_lint/runner.rb:23:in `run'
lib/haml_lint/cli.rb:92:in `scan_for_lints'
lib/haml_lint/cli.rb:51:in `act_on_options'
lib/haml_lint/cli.rb:23:in `run'
bin/haml-lint:7:in `<top (required)>'
```

Second, the `MultilinePipe` linter can raise an error due to a nil line:

```
undefined method `match' for nil:NilClass (NoMethodError)
lib/haml_lint/linter/multiline_pipe.rb:42:in `check'
lib/haml_lint/linter/multiline_pipe.rb:12:in `visit_tag'
lib/haml_lint/haml_visitor.rb:40:in `safe_send'
lib/haml_lint/haml_visitor.rb:19:in `visit'
lib/haml_lint/haml_visitor.rb:30:in `block in visit_children'
lib/haml_lint/haml_visitor.rb:30:in `each'
lib/haml_lint/haml_visitor.rb:30:in `visit_children'
lib/haml_lint/haml_visitor.rb:24:in `visit'
lib/haml_lint/haml_visitor.rb:30:in `block in visit_children'
lib/haml_lint/haml_visitor.rb:30:in `each'
lib/haml_lint/haml_visitor.rb:30:in `visit_children'
lib/haml_lint/haml_visitor.rb:24:in `visit'
lib/haml_lint/linter.rb:28:in `run'
lib/haml_lint/runner.rb:84:in `block in collect_lints'
lib/haml_lint/runner.rb:83:in `map'
lib/haml_lint/runner.rb:83:in `collect_lints'
lib/haml_lint/runner.rb:119:in `process_file'
lib/haml_lint/runner.rb:108:in `block in process_files'
lib/haml_lint/runner.rb:107:in `each'
lib/haml_lint/runner.rb:107:in `process_files'
lib/haml_lint/runner.rb:132:in `report'
lib/haml_lint/runner.rb:23:in `run'
```

Both are fixed by the looser interpretation of line endings.

[1]: https://github.com/haml/haml/blob/1b784bcc50f5f437fd85b9e1a5fe147665d5a5ca/lib/haml/parser.rb#L101