### PR TITLE
Report the real line with lint for LineLength

### DIFF
--- a/lib/haml_lint/linter/line_length.rb
+++ b/lib/haml_lint/linter/line_length.rb
@@ -5,6 +5,11 @@ module HamlLint
   class Linter::LineLength < Linter
     include LinterRegistry
 
+    # A marker for a line within a multiline node.
+    #
+    # @api private
+    DummyNode = Struct.new(:line)
+
     MSG = 'Line is too long. [%d/%d]'.freeze
 
     def visit_root(root)
@@ -15,7 +20,7 @@ module HamlLint
 
         node = root.node_for_line(index + 1)
         unless node.disabled?(self)
-          record_lint(node, format(MSG, line.length, max_length))
+          record_lint(DummyNode.new(index + 1), format(MSG, line.length, max_length))
         end
       end
     end

--- a/lib/haml_lint/tree/node.rb
+++ b/lib/haml_lint/tree/node.rb
@@ -85,6 +85,26 @@ module HamlLint::Tree
       "#<#{self.class.name}>"
     end
 
+    # The lines of text, if any, that are contained in the node.
+    #
+    # @api public
+    # @return [Array<String>]
+    def lines
+      return [] unless @value && text
+
+      text.split(/\r\n|\r|\n/)
+    end
+
+    # The line numbers that are contained within the node.
+    #
+    # @api public
+    # @return [Range]
+    def line_numbers
+      return (line..line) unless @value && text
+
+      (line..line + lines.count)
+    end
+
     # The previous node to be traversed in the tree.
     #
     # @return [HamlLint::Tree::Node, nil]

--- a/lib/haml_lint/tree/root_node.rb
+++ b/lib/haml_lint/tree/root_node.rb
@@ -15,7 +15,7 @@ module HamlLint::Tree
     # @param line [Integer] the line number of the node
     # @return [HamlLint::Node]
     def node_for_line(line)
-      find(-> { HamlLint::Tree::NullNode.new }) { |node| node.line == line }
+      find(-> { HamlLint::Tree::NullNode.new }) { |node| node.line_numbers.cover?(line) }
     end
   end
 end

--- a/spec/haml_lint/linter/line_length_spec.rb
+++ b/spec/haml_lint/linter/line_length_spec.rb
@@ -32,4 +32,19 @@ describe HamlLint::Linter::LineLength do
 
     it { should_not report_lint }
   end
+
+  context 'when a file contains lines within a multiline node that are too long' do
+    let(:haml) do
+      [
+        '- if model.setup_state_manual?',
+        "  = render 'no_validators_box'",
+        '',
+        ':ruby',
+        '  active_engines = model.validators.active.to_a',
+        '  engines = ::BlaBlaBlaBlaBlaBlaBlaBla.decorate_collection(::BlaBlaBlaBlaBla.all)',
+      ].join("\n")
+    end
+
+    it { should report_lint line: 6 }
+  end
 end


### PR DESCRIPTION
When we refactored the LineLength linter to be disableable, we missed
a corner case for multi-line nodes. These nodes were being reported at
line zero because the "find node for line" ability was ignoring the
presence of multiline nodes.

This fixes the ability to find lines within multiline nodes and ensures
the correct line is reported for the LineLength linter.

Closes #196