### PR TITLE
Prevent unexpected syntax from causing a crash

### DIFF
--- a/lib/haml_lint/linter.rb
+++ b/lib/haml_lint/linter.rb
@@ -27,6 +27,16 @@ module HamlLint
       @lints = []
       visit(document.tree)
       @lints
+    rescue Parser::SyntaxError => ex
+      location = ex.diagnostic.location
+      @lints <<
+        HamlLint::Lint.new(
+          HamlLint::Linter::Syntax.new(config),
+          document.file,
+          location.line,
+          ex.to_s,
+          :error
+        )
     end
 
     # Returns the simple name for this linter.

--- a/spec/haml_lint/linter/instance_variables_spec.rb
+++ b/spec/haml_lint/linter/instance_variables_spec.rb
@@ -86,4 +86,30 @@ RSpec.describe HamlLint::Linter::InstanceVariables do
       it { should_not report_lint }
     end
   end
+
+  context 'when the partial is actually an ERB file that writes Haml' do
+    let(:options) do
+      {
+        config: HamlLint::ConfigurationLoader.default_configuration,
+        file: '_partial.html.haml'
+      }
+    end
+
+    let(:haml) do
+      [
+        '<%- model_attrs.each do |attr| -%>',
+        '= form.text_field :<%= attr.name %>',
+        '<%- end -%>',
+        '',
+        '= form.form_group :class => "form-actions" do',
+        '  = form.submit :class => "btn btn-primary"'
+      ].join("\n")
+    end
+
+    it 'does not raise an error' do
+      expect { subject }.not_to raise_error
+    end
+
+    it { should report_lint line: 1, message: 'unterminated string meets end of file' }
+  end
 end


### PR DESCRIPTION
Sometimes people leave a `.haml` extension on a file that isn't plain
Haml. For example, you might have an ERB template that writes Haml for
a Rails generator and forget to change the extension to `.haml.erb`.
This can cause problems with linters that use the Ruby parser, since the
Haml parser cannot correctly interpret the ERB syntax of the file.

To guard against this condition, we can rescue any errors from the
parser gem and wrap them in a `Syntax` lint. This gives the user some
signal that they're doing something unexpected, but lets them lint their
entire project without haml-lint crashing on them.