### PR TITLE
Add support for an `inherits_from` directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,26 @@ leading frontmatter to the template for their own tracking purposes.
 skip_frontmatter: true
 ```
 
+### Inheriting from Other Configuration Files
+
+The `inherits_from` global configuration option allows you to specify an
+inheritance chain for a configuration file. It accepts either a scalar value of
+a single file name or a vector of multiple files to inherit from. The inherited
+files are resolved in a first in, first out order and with "last one wins"
+precedence. For example:
+
+```yaml
+inherits_from:
+  - .shared_haml-lint.yml
+  - .personal_haml-lint.yml
+```
+
+First, the default configuration is loaded. Then the `.shared_haml-lint.yml`
+configuration is loaded, followed by `.personal_haml-lint.yml`. Each of these
+overwrite each other in the event of a collision in configuration value. Once
+the inheritance chain is resolved, the base configuration is loaded and applies
+its rules to overwrite any in the intermediate configuration.
+
 ## Linters
 
 ### [» Linters Documentation](lib/haml_lint/linter/README.md)

--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ overwrite each other in the event of a collision in configuration value. Once
 the inheritance chain is resolved, the base configuration is loaded and applies
 its rules to overwrite any in the intermediate configuration.
 
+Lastly, in order to match your RuboCop configuration style, you can also use the
+`inherit_from` directive, which is an alias for `inherits_from`.
+
 ## Linters
 
 ### [» Linters Documentation](lib/haml_lint/linter/README.md)

--- a/lib/haml_lint/configuration_loader.rb
+++ b/lib/haml_lint/configuration_loader.rb
@@ -70,6 +70,11 @@ module HamlLint
             {}
           end
 
+        if hash.key?('inherit_from')
+          hash['inherits_from'] ||= []
+          hash['inherits_from'].concat(Array(hash.delete('inherit_from')))
+        end
+
         HamlLint::Configuration.new(hash)
       end
 

--- a/spec/haml_lint/configuration_loader_spec.rb
+++ b/spec/haml_lint/configuration_loader_spec.rb
@@ -109,6 +109,146 @@ describe HamlLint::ConfigurationLoader do
         expect { subject }.to raise_error HamlLint::Exceptions::ConfigurationError
       end
     end
+
+    context 'with an "inherits_from" directive' do
+      let(:config_file) do
+        [
+          "inherits_from: #{other_config}",
+          'skip_frontmatter: true',
+          'linters:',
+          '  AltText:',
+          '    enabled: true'
+        ].join("\n")
+      end
+      let(:other_config) { 'other_haml-lint.yml' }
+
+      before do
+        File.open(file_name, 'w') { |f| f.write(config_file) }
+      end
+
+      context 'for a file that does not exist' do
+        it 'extends the default configuration' do
+          custom_config = HamlLint::Configuration.new(
+            'inherits_from' => other_config,
+            'skip_frontmatter' => true,
+            'linters' => {
+              'AltText' => { 'enabled' => true }
+            }
+          )
+
+          subject.should ==
+            described_class.default_configuration.merge(custom_config)
+        end
+      end
+
+      context 'for a file that exists' do
+        let(:other_config_file) do
+          [
+            'linters:',
+            '  AltText:',
+            '    enabled: false',
+            '  Indentation:',
+            '    enabled: false'
+          ].join("\n")
+        end
+
+        before do
+          File.open(other_config, 'w') { |f| f.write(other_config_file) }
+        end
+
+        it 'layers the inherited config on the default with the main file overriding both' do
+          custom_config = HamlLint::Configuration.new(
+            'inherits_from' => other_config,
+            'skip_frontmatter' => true,
+            'linters' => {
+              'AltText' => { 'enabled' => true },
+              'Indentation' => { 'enabled' => false }
+            }
+          )
+
+          subject.should ==
+            described_class.default_configuration.merge(custom_config)
+        end
+
+        context 'when the file has a circular dependency on another' do
+          let(:other_config_file) do
+            [
+              "inherits_from: #{file_name}",
+              'linters:',
+              '  AltText:',
+              '    enabled: false',
+              '  Indentation:',
+              '    enabled: false'
+            ].join("\n")
+          end
+
+          it 'loads each file once and does not start an endless loop' do
+            custom_config = HamlLint::Configuration.new(
+              'inherits_from' => other_config,
+              'skip_frontmatter' => true,
+              'linters' => {
+                'AltText' => { 'enabled' => true },
+                'Indentation' => { 'enabled' => false }
+              }
+            )
+
+            subject.should ==
+              described_class.default_configuration.merge(custom_config)
+          end
+        end
+
+        context 'with multiple files' do
+          let(:config_file) do
+            [
+              'inherits_from:',
+              "  - #{other_config}",
+              "  - #{third_config}",
+              'skip_frontmatter: true',
+              'linters:',
+              '  AltText:',
+              '    enabled: true'
+            ].join("\n")
+          end
+          let(:other_config_file) do
+            [
+              'linters:',
+              '  AltText:',
+              '    enabled: false',
+              '  Indentation:',
+              '    enabled: false'
+            ].join("\n")
+          end
+          let(:third_config) { 'other.yml' }
+          let(:third_config_file) do
+            [
+              'linters:',
+              '  AltText:',
+              '    enabled: true',
+              '  Indentation:',
+              '    enabled: true'
+            ].join("\n")
+          end
+
+          before do
+            File.open(third_config, 'w') { |f| f.write(third_config_file) }
+          end
+
+          it 'loads them all in the correct order' do
+            custom_config = HamlLint::Configuration.new(
+              'inherits_from' => [other_config, third_config],
+              'skip_frontmatter' => true,
+              'linters' => {
+                'AltText' => { 'enabled' => true },
+                'Indentation' => { 'enabled' => true }
+              }
+            )
+
+            subject.should ==
+              described_class.default_configuration.merge(custom_config)
+          end
+        end
+      end
+    end
   end
 
   describe '.load_hash' do

--- a/spec/haml_lint/configuration_loader_spec.rb
+++ b/spec/haml_lint/configuration_loader_spec.rb
@@ -247,6 +247,58 @@ describe HamlLint::ConfigurationLoader do
               described_class.default_configuration.merge(custom_config)
           end
         end
+
+        context 'and an inherit_from directive' do
+          let(:config_file) do
+            [
+              'inherits_from:',
+              "  - #{other_config}",
+              'inherit_from:',
+              "  - #{third_config}",
+              'skip_frontmatter: true',
+              'linters:',
+              '  AltText:',
+              '    enabled: true'
+            ].join("\n")
+          end
+          let(:other_config_file) do
+            [
+              'linters:',
+              '  AltText:',
+              '    enabled: false',
+              '  Indentation:',
+              '    enabled: false'
+            ].join("\n")
+          end
+          let(:third_config) { 'other.yml' }
+          let(:third_config_file) do
+            [
+              'linters:',
+              '  AltText:',
+              '    enabled: true',
+              '  Indentation:',
+              '    enabled: true'
+            ].join("\n")
+          end
+
+          before do
+            File.open(third_config, 'w') { |f| f.write(third_config_file) }
+          end
+
+          it 'combines the inherit_from directive with the inherits_from directive' do
+            custom_config = HamlLint::Configuration.new(
+              'inherits_from' => [other_config, third_config],
+              'skip_frontmatter' => true,
+              'linters' => {
+                'AltText' => { 'enabled' => true },
+                'Indentation' => { 'enabled' => true }
+              }
+            )
+
+            subject.should ==
+              described_class.default_configuration.merge(custom_config)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Borrowing from RuboCop, the idea of inheriting a configuration from
another file is useful because it allows you to have a central
configuration for your team to use across multiple projects. It's also
a necessary feature to make an `--auto-gen-config` command useful by
giving you a configuration that you can inherit from that is generated
from an existing code base.