### PR TITLE
enforce width of indentation spaces

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -47,6 +47,10 @@ linters:
   ImplicitDiv:
     enabled: true
 
+  IndentationSpaces:
+    enabled: true
+    width: 2
+
   InstanceVariables:
     enabled: true
     file_types: partials

--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -15,6 +15,7 @@ Below is a list of linters supported by `haml-lint`, ordered alphabetically.
 * [IdNames](#idnames)
 * [ImplicitDiv](#implicitdiv)
 * [Indentation](#indentation)
+* [IndentationSpaces](#indentationspaces)
 * [InstanceVariables](#instancevariables)
 * [LeadingCommentSpace](#leadingcommentspace)
 * [LineLength](#linelength)
@@ -308,6 +309,32 @@ Check that spaces are used for indentation instead of hard tabs.
 Option          | Description
 ----------------|-------------------------------------------------------------
 `character`     | Character to use for indentation. `space` or `tab` (default `space`)
+
+## IndentationSpaces
+
+Check that the configured number of spaces is used for indentation.
+
+Option        | Description
+--------------|-------------------------------------------------------------
+`width`       | Number of spaces to use per indentation level. (default 2)
+
+**Bad: Button text is indented only 1 space**
+```haml
+%button
+ Hit me
+```
+
+**Good: Button text is indented 2 spaces**
+```haml
+%button
+  Hit me
+```
+
+HAML ordinarily allows any number of spaces (or tabs) to indicate indentation
+levels; this linter forces consistency in the number of spaces used. If tabs
+are being used, this linter always passes.
+
+See the [Indentation](#indentation) rule to require only spaces or only tabs.
 
 ## InstanceVariables
 

--- a/lib/haml_lint/linter/indentation_spaces.rb
+++ b/lib/haml_lint/linter/indentation_spaces.rb
@@ -1,0 +1,22 @@
+module HamlLint
+  # Checks the number of spaces used for indentation.
+  class Linter::IndentationSpaces < Linter
+    include LinterRegistry
+
+    TABS = /^\t+\b/
+
+    def visit_root(root)
+      width = config['width'].to_i
+      regex = /^(?: {#{width}})*(?!\s)/
+      dummy_node = Struct.new(:line)
+
+      document.source_lines.each_with_index do |line, index|
+        next if line =~ regex || line =~ TABS
+
+        unless root.node_for_line(index).disabled?(self)
+          record_lint dummy_node.new(index + 1), "Line does not use #{width}-space indentation"
+        end
+      end
+    end
+  end
+end

--- a/lib/haml_lint/linter/indentation_spaces.rb
+++ b/lib/haml_lint/linter/indentation_spaces.rb
@@ -5,17 +5,35 @@ module HamlLint
 
     TABS = /^\t+\b/
 
-    def visit_root(root)
+    def visit_tag(node)
+      check(node)
+    end
+
+    def visit_script(node)
+      check(node)
+    end
+
+    def visit_silent_script(node)
+      check(node)
+    end
+
+    def visit_plain(node)
+      check(node)
+    end
+
+    private
+
+    def line_text_for_node(node)
+      document.source_lines[node.line - 1]
+    end
+
+    def check(node)
       width = config['width'].to_i
       regex = /^(?: {#{width}})*(?!\s)/
-      dummy_node = Struct.new(:line)
+      line = line_text_for_node(node)
 
-      document.source_lines.each_with_index do |line, index|
-        next if line =~ regex || line =~ TABS
-
-        unless root.node_for_line(index).disabled?(self)
-          record_lint dummy_node.new(index + 1), "Line does not use #{width}-space indentation"
-        end
+      unless line =~ regex || line =~ TABS
+        record_lint node, "Line does not use #{width}-space indentation"
       end
     end
   end

--- a/spec/haml_lint/linter/indentation_spaces_spec.rb
+++ b/spec/haml_lint/linter/indentation_spaces_spec.rb
@@ -56,4 +56,16 @@ describe HamlLint::Linter::IndentationSpaces do
 
     it { should_not report_lint }
   end
+
+  context 'when HAML is split across multiple lines' do
+    let(:haml) { "%span{ alpha: 'bravo',\n       charlie: 'delta' }\n  Hello" }
+
+    it { should_not report_lint }
+
+    context 'unless the following line has the wrong number of spaces' do
+      let(:config) { super().merge('width' => 3) }
+
+      it { should report_lint }
+    end
+  end
 end

--- a/spec/haml_lint/linter/indentation_spaces_spec.rb
+++ b/spec/haml_lint/linter/indentation_spaces_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe HamlLint::Linter::IndentationSpaces do
+  include_context 'linter'
+
+  context 'when line contains no indentation' do
+    let(:haml) { '%span' }
+
+    it { should_not report_lint }
+  end
+
+  context 'when line contains only 1 space for indentation' do
+    let(:haml) { "%span\n Hello" }
+
+    it { should report_lint line: 2 }
+
+    context 'but the linter is disabled in the file' do
+      let(:haml) { "-# haml-lint:disable IndentationSpaces\n" + super() }
+
+      it { should_not report_lint }
+    end
+  end
+
+  context 'when line contains 2 spaces for indentation' do
+    let(:haml) { "%span\n  Hello" }
+
+    it { should_not report_lint }
+
+    context 'but the linter is configured to use 3 spaces' do
+      let(:config) { super().merge('width' => 3) }
+
+      it { should report_lint line: 2 }
+    end
+  end
+
+  context 'when line contains 3 spaces for indentation' do
+    let(:haml) { "%span\n   Hello" }
+
+    it { should report_lint line: 2 }
+
+    context 'but the linter is configured to use 3 spaces' do
+      let(:config) { super().merge('width' => 3) }
+
+      it { should_not report_lint }
+    end
+  end
+
+  context 'when line contains 4 spaces for indentation' do
+    let(:haml) { "%span\n  Hello" }
+
+    it { should_not report_lint }
+  end
+
+  context 'when line contains tabs for indentation' do
+    let(:haml) { "%span\n\tHello" }
+
+    it { should_not report_lint }
+  end
+end


### PR DESCRIPTION
Ensures that HAML is indented by the proper number of spaces (default 2). If tabs are being used, then does nothing (does not infringe on the Indentation linter).