### PR TITLE
Fix bug in auto-gen-config

### DIFF
--- a/lib/haml_lint/options.rb
+++ b/lib/haml_lint/options.rb
@@ -21,7 +21,7 @@ module HamlLint
       end.parse!(args)
 
       # Any remaining arguments are assumed to be files
-      @options[:files] = args
+      @options[:files] = args.empty? ? ["."] : args
 
       @options
     rescue OptionParser::InvalidOption => ex

--- a/lib/haml_lint/reporter/disabled_config_reporter.rb
+++ b/lib/haml_lint/reporter/disabled_config_reporter.rb
@@ -66,8 +66,8 @@ module HamlLint
       if lints.any?
         lints.each do |lint|
           linters_with_lints[lint.linter.name] << lint.filename
+          linters_lint_count[lint.linter.name] += 1
         end
-        linters_lint_count[lint.linter.name] = lints.count
       end
     end
 


### PR DESCRIPTION
The `--auto-gen-config` option, introduced in #204 didn't work due to a bug in the `disabled_config_reporter#finished_file`. :bowtie: 



Also, when you don't specify any directory when calling `haml-lint`, it doesn't inspect any file, while I would expect it to use the current directory to look for files, as Rubocop does.

This is even more confusing when calling it with the option `auto-gen-config`, as you have to call it like:

`haml-lint . --auto-gen-config`

which is really ugly, and it is not what the documentation says. If there is any reason to not change this, I would at least add it to the documentation.

With this two changes I was able to autogenerate my `.haml-lint_todo.yml` file by running `haml-lint --auto-gen-config`.   :tada: :heart: