### PR TITLE
Fix duplicated entries in haml-lint_todo.yml

### DIFF
--- a/lib/haml_lint/reporter/disabled_config_reporter.rb
+++ b/lib/haml_lint/reporter/disabled_config_reporter.rb
@@ -65,7 +65,7 @@ module HamlLint
 
       if lints.any?
         lints.each do |lint|
-          linters_with_lints[lint.linter.name] << lint.filename
+          linters_with_lints[lint.linter.name] |= [lint.filename]
           linters_lint_count[lint.linter.name] += 1
         end
       end


### PR DESCRIPTION
When autogenerating `haml-lint_todo.yml` It seems that every file is added to the exclude section of the haml-lint_todo.yml as many times as offenses it has.

Fixes #208