### PR TITLE
Fix bugs in haml-lint_todo.yml

### DIFF
--- a/lib/haml_lint/reporter/disabled_config_reporter.rb
+++ b/lib/haml_lint/reporter/disabled_config_reporter.rb
@@ -65,7 +65,7 @@ module HamlLint
 
       if lints.any?
         lints.each do |lint|
-          linters_with_lints[lint.linter.name] << lint.filename
+          linters_with_lints[lint.linter.name] |= [lint.filename]
           linters_lint_count[lint.linter.name] += 1
         end
       end

--- a/lib/haml_lint/reporter/disabled_config_reporter.rb
+++ b/lib/haml_lint/reporter/disabled_config_reporter.rb
@@ -79,6 +79,7 @@ module HamlLint
     def config_file_contents
       output = []
       output << HEADING
+      output << 'linters:' if linters_with_lints.any?
       linters_with_lints.each do |linter, files|
         output << generate_config_for_linter(linter, files)
       end
@@ -92,11 +93,11 @@ module HamlLint
     # @return [String] a Yaml-formatted configuration
     def generate_config_for_linter(linter, files)
       [].tap do |output|
-        output << "# Offense count: #{linters_lint_count[linter]}"
-        output << "#{linter}:"
-        output << '  Exclude:'
+        output << "  # Offense count: #{linters_lint_count[linter]}"
+        output << "  #{linter}:"
+        output << '    exclude:'
         files.each do |filename|
-          output << %{    - "#{filename}"}
+          output << %{      - "#{filename}"}
         end
       end.join("\n")
     end

--- a/spec/haml_lint/reporter/disabled_config_reporter_spec.rb
+++ b/spec/haml_lint/reporter/disabled_config_reporter_spec.rb
@@ -35,14 +35,14 @@ RSpec.describe HamlLint::Reporter::DisabledConfigReporter do
     end
 
     context 'when there are lints' do
-      let(:files)        { ['some-filename.haml', 'other-filename.haml'] }
-      let(:lines)        { [502, 724] }
-      let(:descriptions) { ['Description of lint 1', 'Description of lint 2'] }
+      let(:files)        { ['some-filename.haml', 'some-filename.haml', 'other-filename.haml'] }
+      let(:lines)        { [502, 504, 724] }
+      let(:descriptions) { Array.new(3) { |i| "Description of lint #{i + 1}" } }
       let(:header)       { output.split("\n")[0..3].join("\n") }
       let(:linter)       { double(name: 'SomeLinter') }
       let(:offenses)     { output_without_summary.split("\n")[1..-1].join("\n") }
       let(:output_without_summary) { output.split("\n").reject(&:empty?)[0..-2].join("\n") }
-      let(:severities)   { [:warning] * 2 }
+      let(:severities)   { [:warning] * 3 }
       let(:summary)      { output.split("\n")[-4..-1].join("\n") }
 
       let(:lints) do
@@ -53,7 +53,7 @@ RSpec.describe HamlLint::Reporter::DisabledConfigReporter do
 
       # This is a hack to get around the fact that the method isn't called in isolation
       before do
-        linters_with_lints = { linter.name => files }
+        linters_with_lints = { linter.name => files.uniq }
         linters_lint_count = { linter.name => lints.size }
         reporter.__send__(:instance_variable_set, :@linters_with_lints, linters_with_lints)
         reporter.__send__(:instance_variable_set, :@linters_lint_count, linters_lint_count)
@@ -66,12 +66,17 @@ RSpec.describe HamlLint::Reporter::DisabledConfigReporter do
 
       it 'prints each lint on its own line' do
         subject
-        offenses.split("\n").size.should == 4
+        offenses.should == \
+          "other-filename.haml:724 [W] SomeLinter: Description of lint 3\n" \
+          "some-filename.haml:502 [W] SomeLinter: Description of lint 1\n" \
+          "some-filename.haml:504 [W] SomeLinter: Description of lint 2\n" \
+          "3 files inspected, 3 lints detected\n" \
+          'Created .haml-lint_todo.yml.'
       end
 
       it 'prints the summary' do
         subject
-        summary.should == "\n2 files inspected, 2 lints detected\n" \
+        summary.should == "\n3 files inspected, 3 lints detected\n" \
           "Created .haml-lint_todo.yml.\n" \
           'Run `haml-lint --config .haml-lint_todo.yml`, or add '\
           '`inherits_from: .haml-lint_todo.yml` in a .haml-lint.yml file.'
@@ -83,12 +88,59 @@ RSpec.describe HamlLint::Reporter::DisabledConfigReporter do
           [
             described_class::HEADING,
             '',
-            '# Offense count: 2',
-            'SomeLinter:',
-            '  Exclude:',
-            '    - "some-filename.haml"',
-            '    - "other-filename.haml"'
+            'linters:',
+            '',
+            '  # Offense count: 3',
+            '  SomeLinter:',
+            '    exclude:',
+            '      - "some-filename.haml"',
+            '      - "other-filename.haml"'
           ].join("\n")
+      end
+    end
+  end
+
+  describe '#finished_file' do
+    subject { reporter.finished_file(file, lints) }
+
+    context 'when there are no lints' do
+      let(:file) { 'some-filename.haml' }
+      let(:lints) { [] }
+
+      it 'does not log any lints on linters' do
+        expect { subject }.not_to change(reporter, :linters_with_lints)
+      end
+
+      it 'does not log any lint counts' do
+        expect { subject }.not_to change(reporter, :linters_lint_count)
+      end
+    end
+
+    context 'when there are lints' do
+      let(:file) { 'some-filename.haml' }
+      let(:lines)        { [502, 504, 724] }
+      let(:descriptions) { Array.new(3) { |i| "Description of lint #{i + 1}" } }
+      let(:header)       { output.split("\n")[0..3].join("\n") }
+      let(:linter)       { double(name: 'SomeLinter') }
+      let(:offenses)     { output_without_summary.split("\n")[1..-1].join("\n") }
+      let(:output_without_summary) { output.split("\n").reject(&:empty?)[0..-2].join("\n") }
+      let(:severities)   { [:warning] * 3 }
+      let(:summary)      { output.split("\n")[-4..-1].join("\n") }
+
+      let(:lints) do
+        lines.each_with_index.map do |line, index|
+          HamlLint::Lint.new(linter, file, line, descriptions[index], severities[index])
+        end
+      end
+
+      it 'logs lints on the linters' do
+        expect { subject }.to change(reporter, :linters_with_lints).to(
+          'SomeLinter' => ['some-filename.haml']
+        )
+      end
+
+      it 'logs any lint counts' do
+        expect { subject }.to change(reporter, :linters_lint_count).to('SomeLinter' => 3)
       end
     end
   end


### PR DESCRIPTION
This fixes the duplicate files problem when using `--auto-gen-config` using @Ana06's method from #209  the formatting problems that she reported in #207.

It also has tests for both (which is should have originally, but I had a brain fart and forgot that I was mocking out that method).

Closes #207
Closes #208
Closes #209 
