### PR TITLE
Indentation width

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -50,6 +50,7 @@ linters:
   Indentation:
     enabled: true
     character: space # or tab
+    width: 2
 
   InstanceVariables:
     enabled: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -47,6 +47,10 @@ linters:
   ImplicitDiv:
     enabled: true
 
+  Indentation:
+    enabled: true
+    character: space # or tab
+
   InstanceVariables:
     enabled: true
     file_types: partials
@@ -107,10 +111,6 @@ linters:
   SpaceInsideHashAttributes:
     enabled: true
     style: space
-
-  Indentation:
-    enabled: true
-    character: space # or tab
 
   TagName:
     enabled: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -50,7 +50,7 @@ linters:
   Indentation:
     enabled: true
     character: space # or tab
-    width: 2
+    width: 2 # ignored if character == tab
 
   InstanceVariables:
     enabled: true

--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -328,6 +328,8 @@ Option          | Description
   Hit me
 ```
 
+**Note:** `width` is ignored when `character` is set to `tab`.
+
 ## InstanceVariables
 
 Checks that instance variables are not used in the specified type of files.

--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -308,6 +308,25 @@ Check that spaces are used for indentation instead of hard tabs.
 Option          | Description
 ----------------|-------------------------------------------------------------
 `character`     | Character to use for indentation. `space` or `tab` (default `space`)
+`width`         | Number of spaces to use for `space` indentation. (default 2)
+
+**Bad: indentation is 1 space**
+```haml
+%button
+ Hit me
+```
+
+**Bad: indentation is 4 spaces**
+```haml
+%button
+    Hit me
+```
+
+**Good: indentation is 2 spaces**
+```haml
+%button
+  Hit me
+```
 
 ## InstanceVariables
 

--- a/lib/haml_lint/linter/indentation.rb
+++ b/lib/haml_lint/linter/indentation.rb
@@ -9,10 +9,21 @@ module HamlLint
       tab: /^\t*(?![ ])/,
     }.freeze
 
+    LEADING_SPACES_REGEX = /^( +)(?! )/
+
     def visit_root(root)
       character = config['character'].to_sym
-      wrong_characters = character == :space ? 'tabs' : 'spaces'
+      check_character(character, root)
 
+      width = config['width'].to_i
+      check_width(width, root) if character == :space && width > 0
+    end
+
+    private
+
+    # validate that indentation matches config characters (either spaces or tabs)
+    def check_character(character, root)
+      wrong_characters = character == :space ? 'tabs' : 'spaces'
       regex = INDENT_REGEX[character]
       dummy_node = Struct.new(:line)
 
@@ -21,6 +32,24 @@ module HamlLint
 
         unless root.node_for_line(index).disabled?(self)
           record_lint dummy_node.new(index + 1), "Line contains #{wrong_characters} in indentation"
+        end
+      end
+    end
+
+    # validate that indentation matches config width (only for spaces)
+    def check_width(width, root)
+      dummy_node = Struct.new(:line)
+
+      # to avoid excessive noise, only check children of top level nodes
+      # if indentation is proper below that, then `haml` will warn about inconsistent indentation
+      root.children.each do |top_node|
+        top_node.children.each do |node|
+          line = node.source_code
+          match = LEADING_SPACES_REGEX.match(line)
+
+          if match && match[1] != ' ' * width && !node.disabled?(self)
+            record_lint dummy_node.new(node.line), "Line is not indented #{width} spaces"
+          end
         end
       end
     end

--- a/lib/haml_lint/linter/indentation.rb
+++ b/lib/haml_lint/linter/indentation.rb
@@ -10,14 +10,17 @@ module HamlLint
     }.freeze
 
     def visit_root(root)
-      regex = INDENT_REGEX[config['character'].to_sym]
+      character = config['character'].to_sym
+      wrong_characters = character == :space ? 'tabs' : 'spaces'
+
+      regex = INDENT_REGEX[character]
       dummy_node = Struct.new(:line)
 
       document.source_lines.each_with_index do |line, index|
         next if line =~ regex
 
         unless root.node_for_line(index).disabled?(self)
-          record_lint dummy_node.new(index + 1), 'Line contains tabs in indentation'
+          record_lint dummy_node.new(index + 1), "Line contains #{wrong_characters} in indentation"
         end
       end
     end

--- a/spec/haml_lint/linter/indentation_spec.rb
+++ b/spec/haml_lint/linter/indentation_spec.rb
@@ -15,7 +15,56 @@ describe HamlLint::Linter::Indentation do
         Hello
     HAML
 
+    context 'when preferred width is 2 spaces' do
+      it { should_not report_lint }
+    end
+
+    context 'when preferred width is 1 space' do
+      let(:config) { super().merge('width' => 1) }
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when preferred width is 4 spaces' do
+      let(:config) { super().merge('width' => 4) }
+
+      it { should report_lint line: 2 }
+    end
+
+    context 'when preferred width is unset' do
+      let(:config) { super().merge('width' => nil) }
+
+      it { should_not report_lint }
+    end
+  end
+
+  context 'when haml element spans multiple lines' do
+    let(:haml) { <<-HAML }
+      %span{ alpha: :bravo,
+             charlie: :delta }
+    HAML
+
     it { should_not report_lint }
+
+    context 'and a child element is properly indented' do
+      let(:haml) { <<-HAML }
+        %span{ alpha: :bravo,
+               charlie: :delta }
+          Hello
+      HAML
+
+      it { should_not report_lint }
+    end
+
+    context 'but a child element is improperly indented' do
+      let(:haml) { <<-HAML }
+        %span{ alpha: :bravo,
+               charlie: :delta }
+            Hello
+      HAML
+
+      it { should report_lint line: 3 }
+    end
   end
 
   context 'when line contains only tabs for indentation' do
@@ -64,6 +113,12 @@ describe HamlLint::Linter::Indentation do
       HAML
 
       it { should_not report_lint }
+
+      context 'and should ignore the preferred width' do
+        let(:config) { super().merge('width' => 42) }
+
+        it { should_not report_lint }
+      end
     end
   end
 end


### PR DESCRIPTION
Added support for `width` config option in the `indentation` linter. The option is only used when `character` is set to `space` (this allows the default `width` to be `2` without messing up people who are using `character: tab`, and makes more sense since probably nobody uses multiple tabs as indentation).

Includes some minor refactoring of the linter to meet Rubocop complexity standards.

Note that only the first level of indentation is checked; newer versions of `haml` now check for inconsistent indentation and raise syntax errors, and I thought it would add too much noise to flag consistently incorrect indentation throughout an entire HAML file.

This PR is a superior alternative to PR #205 and addresses the points raised therein. It also addresses another issue: #205 would have improperly allowed indentation of 4, 6, 8, etc. spaces (when `width: 2`).