### PR TITLE
Configurable consecutive comments

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -22,6 +22,7 @@ linters:
 
   ConsecutiveComments:
     enabled: true
+    max_consecutive: 1
 
   ConsecutiveSilentScripts:
     enabled: true

--- a/lib/haml_lint/linter/README.md
+++ b/lib/haml_lint/linter/README.md
@@ -132,6 +132,10 @@ consistent vertical alignment of IDs.
 
 ## ConsecutiveComments
 
+Option            | Description
+------------------|-------------------------------------------------------------
+`max_consecutive` | Maximum number of consecutive comments allowed before warning (default `1`)
+
 Consecutive comments should be condensed into a single multiline comment.
 
 **Bad**

--- a/lib/haml_lint/linter/consecutive_comments.rb
+++ b/lib/haml_lint/linter/consecutive_comments.rb
@@ -11,6 +11,7 @@ module HamlLint
       HamlLint::Utils.for_consecutive_items(
         possible_group(node),
         COMMENT_DETECTOR,
+        config['max_consecutive'] + 1,
       ) do |group|
         group.each { |group_node| reported_nodes << group_node }
         record_lint(group.first,

--- a/spec/haml_lint/linter/consecutive_comments_spec.rb
+++ b/spec/haml_lint/linter/consecutive_comments_spec.rb
@@ -58,7 +58,7 @@ describe HamlLint::Linter::ConsecutiveComments do
     it { should report_lint line: 8 }
 
     context 'but the linter is disabled in the file' do
-      let(:haml) { "-# haml-lint:disable ConsecutiveSilentScripts\n" + super() }
+      let(:haml) { "-# haml-lint:disable ConsecutiveComments\n" + super() }
 
       it { should_not report_lint }
     end

--- a/spec/haml_lint/linter/consecutive_comments_spec.rb
+++ b/spec/haml_lint/linter/consecutive_comments_spec.rb
@@ -36,4 +36,31 @@ describe HamlLint::Linter::ConsecutiveComments do
       it { should_not report_lint }
     end
   end
+
+  context 'when the max_consecutive option is set' do
+    let(:config) { super().merge('max_consecutive' => 3) }
+    let(:haml) { <<-HAML }
+      -# A collection
+      -# of many
+      -# consecutive comments
+      %tag
+      .class
+      -# Individual comment
+      #id
+      -# Another collection
+      -# of consecutive comments
+      -# and another one
+      -# and another one
+    HAML
+
+    it { should_not report_lint line: 1 }
+    it { should_not report_lint line: 6 }
+    it { should report_lint line: 8 }
+
+    context 'but the linter is disabled in the file' do
+      let(:haml) { "-# haml-lint:disable ConsecutiveSilentScripts\n" + super() }
+
+      it { should_not report_lint }
+    end
+  end
 end


### PR DESCRIPTION
This PR add the ability to configure the maximum number of consecutive comments are allowed before the ConsectiveComment linter kicks in.