### PR TITLE
Ensure TrailingWhitespace reports actual line

### DIFF
--- a/lib/haml_lint/linter/trailing_whitespace.rb
+++ b/lib/haml_lint/linter/trailing_whitespace.rb
@@ -3,13 +3,15 @@ module HamlLint
   class Linter::TrailingWhitespace < Linter
     include LinterRegistry
 
+    DummyNode = Struct.new(:line)
+
     def visit_root(root)
       document.source_lines.each_with_index do |line, index|
         next unless line =~ /\s+$/
 
         node = root.node_for_line(index + 1)
         unless node.disabled?(self)
-          record_lint node, 'Line contains trailing whitespace'
+          record_lint DummyNode.new(index + 1), 'Line contains trailing whitespace'
         end
       end
     end

--- a/spec/haml_lint/linter/trailing_whitespace_spec.rb
+++ b/spec/haml_lint/linter/trailing_whitespace_spec.rb
@@ -27,6 +27,19 @@ describe HamlLint::Linter::TrailingWhitespace do
     end
   end
 
+  context 'for a multiline node' do
+    let(:haml) do
+      [
+        '= content_for :head_javascript do',
+        '  :plain',
+        '    var arch_to_show = "#{@default_architecture}"; ',
+        '    var time_to_show = "24";'
+      ].join("\n")
+    end
+
+    it { should report_lint line: 3 }
+  end
+
   context 'when line contains trailing newline' do
     let(:haml) { "- some_code_with_trailing_whitespace\n" }
 


### PR DESCRIPTION
We were reporting on the line for the container node when using
multiline nodes instead of the real line. This was confusing and
inaccurate.

Closes #220