### PR TITLE
Add haml 4.1 to supported versions

### DIFF
--- a/lib/haml_lint/adapter.rb
+++ b/lib/haml_lint/adapter.rb
@@ -17,6 +17,7 @@ module HamlLint
       version = haml_version
       case version
       when '~> 4.0' then HamlLint::Adapter::Haml4
+      when '~> 4.1' then HamlLint::Adapter::Haml4
       when '~> 5.0' then HamlLint::Adapter::Haml5
       else fail HamlLint::Exceptions::UnknownHamlVersion, "Cannot handle Haml version: #{version}"
       end

--- a/spec/haml_lint/adapter_spec.rb
+++ b/spec/haml_lint/adapter_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe HamlLint::Adapter do
       it { should == HamlLint::Adapter::Haml4 }
     end
 
+    context 'on Haml 4.1.beta' do
+      before { stub_const('Haml::VERSION', '4.1.0.beta.1') }
+
+      it { should == HamlLint::Adapter::Haml4 }
+    end
+
     context 'on Haml 5' do
       before { stub_const('Haml::VERSION', '5.0.0.beta.2') }
 


### PR DESCRIPTION
See #228 

Adding this allows haml-lint to start with haml 4.1.0.beta.1.
I didn't have time to check for breaking changes in that version, so it may be that it breaks something.