### PR TITLE
Support the stable version of Haml 5

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -7,5 +7,5 @@ appraise 'haml4.1-beta' do
 end
 
 appraise 'haml5' do
-  gem 'haml', '~> 5.0.0.beta.2', git: 'https://github.com/haml/haml.git'
+  gem 'haml', '~> 5.0.0'
 end

--- a/gemfiles/haml4.1_beta.gemfile
+++ b/gemfiles/haml4.1_beta.gemfile
@@ -5,9 +5,9 @@ source "https://rubygems.org"
 gem "rspec", "~> 3.0"
 gem "rspec-its", "~> 1.0"
 gem "appraisal"
-gem "overcommit", "0.37.0"
-gem "rubocop", "0.47.0"
-gem "coveralls", require: false
+gem "overcommit", "0.39.1"
+gem "rubocop", "0.48.1"
+gem "coveralls", :require => false
 gem "haml", "4.1.0.beta.1"
 
-gemspec path: "../"
+gemspec :path => "../"

--- a/gemfiles/haml4.gemfile
+++ b/gemfiles/haml4.gemfile
@@ -5,9 +5,9 @@ source "https://rubygems.org"
 gem "rspec", "~> 3.0"
 gem "rspec-its", "~> 1.0"
 gem "appraisal"
-gem "overcommit", "0.37.0"
-gem "rubocop", "0.47.0"
-gem "coveralls", require: false
+gem "overcommit", "0.39.1"
+gem "rubocop", "0.48.1"
+gem "coveralls", :require => false
 gem "haml", "~> 4"
 
-gemspec path: "../"
+gemspec :path => "../"

--- a/gemfiles/haml5.gemfile
+++ b/gemfiles/haml5.gemfile
@@ -5,9 +5,9 @@ source "https://rubygems.org"
 gem "rspec", "~> 3.0"
 gem "rspec-its", "~> 1.0"
 gem "appraisal"
-gem "overcommit", "0.37.0"
-gem "rubocop", "0.47.0"
-gem "coveralls", require: false
-gem "haml", "~> 5.0.0.beta.2", git: "https://github.com/haml/haml.git"
+gem "overcommit", "0.39.1"
+gem "rubocop", "0.48.1"
+gem "coveralls", :require => false
+gem "haml", "~> 5.0.0"
 
-gemspec path: "../"
+gemspec :path => "../"


### PR DESCRIPTION
Haml changed their domain model for syntax tree nodes in between
5.0.0.beta2 and 5.0.0 stable. This caused a problem with extracting the
dynamic attributes from tag nodes.

In order to maintain compatibility between Haml 4 and Haml 5, we have to
switch on the detected version of Haml and handle the dynamic attributes
differently between 4 and 5.

Haml 5 also has a subtle bug in it where the syntax tree node mutates
itself between method calls. This means that we have to memoize the
result of converting it to a literal because subsequent calls will
return a different, invalid result.

## Question

What do we think of doing the version check where I have it. I would love
to have a single place where we switch behavior based on the version of
Haml, but couldn't think of a decent way to handle it in this case. We have
[the adapter class] that we could expand, but that seems like it could get
messy quickly.

We could also add a predicate method to the adapter to do the version
check and then just keep the forks in the methods.

We could also keep doing it ad-hoc like this.

What do you all think?

Closes #224

[the adapter class]: https://github.com/brigade/haml-lint/blob/master/lib/haml_lint/adapter.rb