### PR TITLE
Fix finding attributes when assigned dynamically

### DIFF
--- a/lib/haml_lint/report.rb
+++ b/lib/haml_lint/report.rb
@@ -16,7 +16,7 @@ module HamlLint
     # @param files [Array<String>] files that were linted
     # @param fail_level [Symbol] the severity level to fail on
     # @param reporter [HamlLint::Reporter] the reporter for the report
-    def initialize(lints = [], files = [], fail_level = :warning, reporter:)
+    def initialize(lints = [], files = [], fail_level = :warning, reporter: nil)
       @lints = lints.sort_by { |l| [l.filename, l.line] }
       @files = files
       @fail_level = Severity.new(fail_level)

--- a/lib/haml_lint/tree/tag_node.rb
+++ b/lib/haml_lint/tree/tag_node.rb
@@ -1,5 +1,6 @@
 module HamlLint::Tree
   # Represents a tag node in a HAML document.
+  # rubocop:disable ClassLength
   class TagNode < Node
     # Computed set of attribute hashes code.
     #

--- a/lib/haml_lint/tree/tag_node.rb
+++ b/lib/haml_lint/tree/tag_node.rb
@@ -234,7 +234,9 @@ module HamlLint::Tree
     private
 
     def existing_attributes
-      parsed_attributes.children.collect do |parsed_attribute|
+      parsed_attrs = parsed_attributes
+      return {} unless parsed_attrs.respond_to?(:children)
+      parsed_attrs.children.collect do |parsed_attribute|
         parsed_attribute.children.first.to_a.first
       end
     end

--- a/spec/haml_lint/tree/tag_node_spec.rb
+++ b/spec/haml_lint/tree/tag_node_spec.rb
@@ -37,6 +37,12 @@ describe HamlLint::Tree::TagNode do
 
       it { should == false }
     end
+
+    context 'when the node has attributes from a variable' do
+      let(:haml) { '%my_tag{some_variable}' }
+
+      it { should == false }
+    end
   end
 
   describe '#dynamic_attributes_source' do


### PR DESCRIPTION
In haml, you can assign attributes dynamically this way:

  %foo{ foo_attributes }

where `foo_attributes` is a method identifier or a variable. With the
newly added InlineStyles linter (619d581), we exposed a dormant bug with
how we look for attributes in a node in tag_node.rb. The following error
would be thrown when trying to lint the above code:

  undefined method `children' for false:HamlLint::ParsedRuby

I applied a somewhat naive fix by just returning early if `children`
isn't there.

Fixes #232
