### PR TITLE
Disable linters with many offenses in todo file

### DIFF
--- a/lib/haml_lint/options.rb
+++ b/lib/haml_lint/options.rb
@@ -21,7 +21,7 @@ module HamlLint
       end.parse!(args)
 
       # Any remaining arguments are assumed to be files
-      @options[:files] = args.empty? ? ["."] : args
+      @options[:files] = args.empty? ? ['.'] : args
 
       @options
     rescue OptionParser::InvalidOption => ex

--- a/lib/haml_lint/reporter/disabled_config_reporter.rb
+++ b/lib/haml_lint/reporter/disabled_config_reporter.rb
@@ -95,9 +95,15 @@ module HamlLint
       [].tap do |output|
         output << "  # Offense count: #{linters_lint_count[linter]}"
         output << "  #{linter}:"
-        output << '    exclude:'
-        files.each do |filename|
-          output << %{      - "#{filename}"}
+        # disable the linter when there are many files with offenses.
+        # exclude the affected files otherwise.
+        if files.count > 15
+          output << '    enabled: false'
+        else
+          output << '    exclude:'
+          files.each do |filename|
+            output << %{      - "#{filename}"}
+          end
         end
       end.join("\n")
     end

--- a/spec/haml_lint/reporter/disabled_config_reporter_spec.rb
+++ b/spec/haml_lint/reporter/disabled_config_reporter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe HamlLint::Reporter::DisabledConfigReporter do
   let(:io)       { StringIO.new }
   let(:output)   { io.string }
   let(:logger)   { HamlLint::Logger.new(io) }
-  let(:report)   { HamlLint::Report.new(lints, files, reporter: reporter) }
+  let(:report)   { HamlLint::Report.new(lints, files.uniq, reporter: reporter) }
   let(:reporter) { described_class.new(logger) }
 
   around do |example|
@@ -64,7 +64,7 @@ RSpec.describe HamlLint::Reporter::DisabledConfigReporter do
           name = index < files1.length ? linters[0].name : linters[1].name
           offenses_msg += "#{file}:#{lines[index]} [W] #{name}: Description of lint #{index + 1}\n"
         end
-        offenses_msg += "19 files inspected, 19 lints detected\n"
+        offenses_msg += "18 files inspected, 19 lints detected\n"
         offenses_msg + 'Created .haml-lint_todo.yml.'
       end
 
@@ -88,7 +88,7 @@ RSpec.describe HamlLint::Reporter::DisabledConfigReporter do
 
       it 'prints the summary' do
         subject
-        summary.should == "\n19 files inspected, 19 lints detected\n" \
+        summary.should == "\n18 files inspected, 19 lints detected\n" \
           "Created .haml-lint_todo.yml.\n" \
           'Run `haml-lint --config .haml-lint_todo.yml`, or add '\
           '`inherits_from: .haml-lint_todo.yml` in a .haml-lint.yml file.'


### PR DESCRIPTION
When autogenerating the todo file we used to list as excluded all the files with offenses. This looks horrible when having many files. :worried: 

Now when we have more than 15 files we exclude the lint instead, similarly as it is done in Rubocop. :bowtie: 

Closes https://github.com/brigade/haml-lint/issues/223