### PR TITLE
Fix UnnecessaryInterpolation for 2-char variables

### DIFF
--- a/lib/haml_lint/linter/unnecessary_interpolation.rb
+++ b/lib/haml_lint/linter/unnecessary_interpolation.rb
@@ -10,7 +10,7 @@ module HamlLint
     include LinterRegistry
 
     def visit_tag(node)
-      return if node.script.empty?
+      return if node.script.length <= 2
 
       count = 0
       chars = 2 # Include surrounding quote chars

--- a/spec/haml_lint/linter/unnecessary_interpolation_spec.rb
+++ b/spec/haml_lint/linter/unnecessary_interpolation_spec.rb
@@ -30,4 +30,9 @@ describe HamlLint::Linter::UnnecessaryInterpolation do
     HAML
     it { should_not report_lint }
   end
+
+  context 'when a non-interpolated 2-char variable is used' do
+    let(:haml) { '%tag= ab' }
+    it { should_not report_lint }
+  end
 end


### PR DESCRIPTION
Two-character-long variable names would give a false positive for the
UnnecessaryInterpolation linter.

This patch fixes this issue and adds the relevant spec.

Checking the length of the script within a node is enough to do so.
As a script that contains an interpolation is at least more than 3 chars
long (#{}), limiting this linter to scripts with 3 or more char will
not have harmful effect, and will fix the issue at the same time.