### PR TITLE
Enable RuboCop linter

### DIFF
--- a/lib/haml_lint/linter/rubocop.rb
+++ b/lib/haml_lint/linter/rubocop.rb
@@ -26,7 +26,12 @@ module HamlLint
     def find_lints(ruby, source_map)
       rubocop = ::RuboCop::CLI.new
 
-      filename = document.file || 'ruby_script'
+      filename =
+        if document.file
+          "#{document.file}.rb"
+        else
+          'ruby_script.rb'
+        end
 
       with_ruby_from_stdin(ruby) do
         extract_lints_from_offenses(lint_file(rubocop, filename), source_map)


### PR DESCRIPTION
Since RuboCop 0.48.0, RuboCop only analyses `.rb` files.
See. https://github.com/bbatsov/rubocop/pull/3997

So, with RuboCop 0.48.0 or higher, HAML-Lint's RuboCop linter doesn't work.


For example


`test.haml`

```haml
- name = 'James Brown'
- unused_variable = 42

%p Hello #{name}!
```

```bash
# without this patch
$ haml-lint test.haml
warning: parser/current is loading parser/ruby24, which recognizes
warning: 2.4.0-compliant syntax, but you are running 2.4.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.

1 file inspected, 0 lints detected

# with this patch, I can get the following output.
$ haml-lint test.haml
warning: parser/current is loading parser/ruby24, which recognizes
warning: 2.4.0-compliant syntax, but you are running 2.4.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
test.haml:2 [W] RuboCop: Useless assignment to variable - `unused_variable`.

1 file inspected, 1 lint detected
```



