### PR TITLE
Use RuboCop severity levels to inform RuboCop lint

### DIFF
--- a/spec/haml_lint/linter/rubocop_spec.rb
+++ b/spec/haml_lint/linter/rubocop_spec.rb
@@ -1,69 +1,104 @@
 require 'spec_helper'
 
 describe HamlLint::Linter::RuboCop do
-  let!(:rubocop_cli) { spy('rubocop_cli') }
-
-  # Need this block before including linter context so that stubbing occurs
-  # before linter is run
-  before do
-    ::RuboCop::CLI.stub(:new).and_return(rubocop_cli)
-    HamlLint::OffenseCollector.stub(:offenses)
-                              .and_return([offence].compact)
+  it 'exhaustively maps RuboCop severity levels to HamlLint severity levels' do
+    ::RuboCop::Cop::Severity::NAMES.each do |name|
+      expect(described_class::SEVERITY_MAP).to have_key(name)
+    end
   end
 
-  include_context 'linter'
+  context 'general testing' do
+    let!(:rubocop_cli) { spy('rubocop_cli') }
 
-  let(:offence) { nil }
-
-  let(:haml) { <<-HAML }
-    %span To be
-    %span= "or not"
-    %span to be
-  HAML
-
-  it 'does not specify the --config flag by default' do
-    expect(rubocop_cli).to have_received(:run).with(array_excluding('--config'))
-  end
-
-  context 'when RuboCop does not report offences' do
-    it { should_not report_lint }
-  end
-
-  context 'when RuboCop reports offences' do
-    let(:line) { 6 }
-    let(:message) { 'Lint message' }
-    let(:cop_name) { 'Lint/SomeCopName' }
-
-    let(:offence) do
-      double('offence', line: line, message: message, cop_name: cop_name)
+    # Need this block before including linter context so that stubbing occurs
+    # before linter is run
+    before do
+      ::RuboCop::CLI.stub(:new).and_return(rubocop_cli)
+      HamlLint::OffenseCollector.stub(:offenses)
+                                .and_return([offence].compact)
     end
 
-    it 'uses the source map to transform line numbers' do
-      subject.should report_lint line: 3
+    include_context 'linter'
+
+    let(:offence) { nil }
+
+    let(:haml) { <<-HAML }
+      %span To be
+      %span= "or not"
+      %span to be
+    HAML
+
+    it 'does not specify the --config flag by default' do
+      expect(rubocop_cli).to have_received(:run).with(array_excluding('--config'))
     end
 
-    context 'and the offence is from an ignored cop' do
-      let(:cop_name) { 'Metrics/LineLength' }
+    context 'when RuboCop does not report offences' do
+      it { should_not report_lint }
+    end
+
+    context 'when RuboCop reports offences' do
+      let(:line) { 6 }
+      let(:message) { 'Lint message' }
+      let(:cop_name) { 'Lint/SomeCopName' }
+      let(:severity) { double('Severity', name: :warning) }
+
+      let(:offence) do
+        double('offence', line: line, message: message, cop_name: cop_name, severity: severity)
+      end
+
+      it 'uses the source map to transform line numbers' do
+        subject.should report_lint line: 3
+      end
+
+      context 'and the offence is from an ignored cop' do
+        let(:cop_name) { 'Metrics/LineLength' }
+        it { should_not report_lint }
+      end
+    end
+
+    context 'when the HAML_LINT_RUBOCOP_CONF environment variable is specified' do
+      around do |example|
+        HamlLint::Utils.with_environment 'HAML_LINT_RUBOCOP_CONF' => 'some-rubocop.yml' do
+          example.run
+        end
+      end
+
+      it 'specifies the --config flag' do
+        expect(rubocop_cli)
+          .to have_received(:run).with(array_including('--config', 'some-rubocop.yml'))
+      end
+    end
+
+    context 'when running inspecting a file containing CRLF line endings (#GH-167)' do
+      let(:haml) { "- if signed_in?(viewer)\r\n%span Stuff" }
+
       it { should_not report_lint }
     end
   end
 
-  context 'when the HAML_LINT_RUBOCOP_CONF environment variable is specified' do
-    around do |example|
-      HamlLint::Utils.with_environment 'HAML_LINT_RUBOCOP_CONF' => 'some-rubocop.yml' do
-        example.run
+  context 'specific testing' do
+    include_context 'linter'
+
+    context 'for a syntax error' do
+      let(:haml) do
+        [
+          ':ruby',
+          '  [].each do |f|',
+        ].join("\n")
       end
+
+      it { should report_lint line: 2, severity: :error }
     end
 
-    it 'specifies the --config flag' do
-      expect(rubocop_cli)
-        .to have_received(:run).with(array_including('--config', 'some-rubocop.yml'))
+    context 'for a simple warning' do
+      let(:haml) do
+        [
+          ':ruby',
+          '  a = 1',
+        ].join("\n")
+      end
+
+      it { should report_lint line: 2, severity: :warning }
     end
-  end
-
-  context 'when running inspecting a file containing CRLF line endings (#GH-167)' do
-    let(:haml) { "- if signed_in?(viewer)\r\n%span Stuff" }
-
-    it { should_not report_lint }
   end
 end


### PR DESCRIPTION
Currently, we set all RuboCop lint to the "warning" severity level, even
when the offense is more dire than a "warning". This changes the way
RuboCop lint is constructed so that we give a more accurate
representation of the lint to the end user.

This also adds a test to make sure we cover any new severity levels in
RuboCop and, in the case of a missing severity, defaults the lint to the
"warning" level as it used to be.

Closes #248