### PR TITLE
Ensure that fail-level and fail-fast work together

### DIFF
--- a/lib/haml_lint/report.rb
+++ b/lib/haml_lint/report.rb
@@ -16,7 +16,7 @@ module HamlLint
     # @param files [Array<String>] files that were linted
     # @param fail_level [Symbol] the severity level to fail on
     # @param reporter [HamlLint::Reporter] the reporter for the report
-    def initialize(lints = [], files = [], fail_level = :warning, reporter: nil)
+    def initialize(lints: [], files: [], fail_level: :warning, reporter: nil)
       @lints = lints.sort_by { |l| [l.filename, l.line] }
       @files = files
       @fail_level = Severity.new(fail_level)
@@ -29,7 +29,7 @@ module HamlLint
     # @return [void]
     def add_lint(lint)
       lints << lint
-      @reporter.added_lint(lint)
+      @reporter.added_lint(lint, self)
     end
 
     # Displays the report via the configured reporter.

--- a/lib/haml_lint/reporter/default_reporter.rb
+++ b/lib/haml_lint/reporter/default_reporter.rb
@@ -6,8 +6,8 @@ module HamlLint
   class Reporter::DefaultReporter < Reporter
     include Reporter::Utils
 
-    def added_lint(lint)
-      print_lint(lint)
+    def added_lint(lint, report)
+      print_lint(lint) if lint.severity >= report.fail_level
     end
 
     def display_report(report)

--- a/lib/haml_lint/reporter/hooks.rb
+++ b/lib/haml_lint/reporter/hooks.rb
@@ -5,8 +5,9 @@ module HamlLint
       # A hook that is called for each lint as it is detected.
       #
       # @param _lint [HamlLint::Lint] the lint added to the report
+      # @param _report [HamlLint::Report] the report that contains the lint
       # @return [void]
-      def added_lint(_lint); end
+      def added_lint(_lint, _report); end
 
       # A hook that is called for each file as it is finished processing.
       #

--- a/lib/haml_lint/runner.rb
+++ b/lib/haml_lint/runner.rb
@@ -127,7 +127,7 @@ module HamlLint
     # @option options :reporter [HamlLint::Reporter] the reporter to report with
     # @return [HamlLint::Report]
     def report(options)
-      report = HamlLint::Report.new(reporter: options[:reporter])
+      report = HamlLint::Report.new(reporter: options[:reporter], fail_level: options[:fail_level])
       report.start(@files)
       process_files(report)
       report

--- a/spec/haml_lint/report_spec.rb
+++ b/spec/haml_lint/report_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe HamlLint::Report do
   let(:logger) { HamlLint::Logger.new(StringIO.new) }
   let(:reporter) { HamlLint::Reporter::DefaultReporter.new(logger) }
 
-  subject(:report) { described_class.new(lints, filenames, fail_level, reporter: reporter) }
+  subject(:report) do
+    described_class.new(lints: lints, files: filenames,
+                        fail_level: fail_level, reporter: reporter)
+  end
 
   describe '#failed?' do
     subject { report.failed? }

--- a/spec/haml_lint/reporter/checkstyle_reporter_spec.rb
+++ b/spec/haml_lint/reporter/checkstyle_reporter_spec.rb
@@ -5,7 +5,7 @@ describe HamlLint::Reporter::CheckstyleReporter do
     let(:io) { StringIO.new }
     let(:output) { io.string }
     let(:logger) { HamlLint::Logger.new(io) }
-    let(:report) { HamlLint::Report.new(lints, [], reporter: reporter) }
+    let(:report) { HamlLint::Report.new(lints: lints, files: [], reporter: reporter) }
     let(:reporter) { described_class.new(logger) }
     let(:linter) { HamlLint::Linter::FinalNewline }
 

--- a/spec/haml_lint/reporter/default_reporter_spec.rb
+++ b/spec/haml_lint/reporter/default_reporter_spec.rb
@@ -5,11 +5,11 @@ describe HamlLint::Reporter::DefaultReporter do
   let(:io) { StringIO.new }
   let(:output) { io.string }
   let(:logger) { HamlLint::Logger.new(io) }
-  let(:report) { HamlLint::Report.new(lints, filenames, reporter: reporter) }
+  let(:report) { HamlLint::Report.new(lints: lints, files: filenames, reporter: reporter) }
   let(:reporter) { described_class.new(logger) }
 
   describe '#added_lint' do
-    subject { lints.each { |lint| reporter.added_lint(lint) } }
+    subject { lints.each { |lint| reporter.added_lint(lint, report) } }
 
     context 'when there are no lints' do
       let(:lints) { [] }

--- a/spec/haml_lint/reporter/disabled_config_reporter_spec.rb
+++ b/spec/haml_lint/reporter/disabled_config_reporter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe HamlLint::Reporter::DisabledConfigReporter do
   let(:io)       { StringIO.new }
   let(:output)   { io.string }
   let(:logger)   { HamlLint::Logger.new(io) }
-  let(:report)   { HamlLint::Report.new(lints, files.uniq, reporter: reporter) }
+  let(:report)   { HamlLint::Report.new(lints: lints, files: files.uniq, reporter: reporter) }
   let(:reporter) { described_class.new(logger) }
 
   around do |example|

--- a/spec/haml_lint/reporter/json_reporter_spec.rb
+++ b/spec/haml_lint/reporter/json_reporter_spec.rb
@@ -5,7 +5,7 @@ describe HamlLint::Reporter::JsonReporter do
     let(:io) { StringIO.new }
     let(:output) { JSON.parse(io.string) }
     let(:logger) { HamlLint::Logger.new(io) }
-    let(:report) { HamlLint::Report.new(lints, [], reporter: reporter) }
+    let(:report) { HamlLint::Report.new(lints: lints, files: [], reporter: reporter) }
     let(:reporter) { described_class.new(logger) }
     let(:offenses) { output['files'].flat_map { |f| f['offenses'] } }
 

--- a/spec/haml_lint/reporter/progress_reporter_spec.rb
+++ b/spec/haml_lint/reporter/progress_reporter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe HamlLint::Reporter::ProgressReporter do
   let(:io)       { StringIO.new }
   let(:output)   { io.string }
   let(:logger)   { HamlLint::Logger.new(io) }
-  let(:report)   { HamlLint::Report.new(lints, files, reporter: reporter) }
+  let(:report)   { HamlLint::Report.new(lints: lints, files: files, reporter: reporter) }
   let(:reporter) { described_class.new(logger) }
 
   describe '#finished_file' do

--- a/spec/haml_lint/runner_spec.rb
+++ b/spec/haml_lint/runner_spec.rb
@@ -11,79 +11,112 @@ describe HamlLint::Runner do
   end
 
   describe '#run' do
-    let(:files) { %w[file1.slim file2.slim] }
-    let(:mock_linter) { double('linter', lints: [], name: 'Blah') }
-
-    let(:options) do
-      base_options.merge(files: files, reporter: reporter)
-    end
-
     subject { runner.run(options) }
 
-    before do
-      runner.stub(:collect_lints).and_return([])
-    end
+    context 'general tests' do
+      let(:files) { %w[file1.slim file2.slim] }
+      let(:mock_linter) { double('linter', lints: [], name: 'Blah') }
 
-    it 'searches for lints in each file' do
-      runner.should_receive(:collect_lints).exactly(files.size).times
-      subject
-    end
-
-    context 'when :config_file option is specified' do
-      let(:options) { base_options.merge(config_file: 'some-config.yml') }
-      let(:config) { double('config') }
-
-      it 'loads that specified configuration file' do
-        config.stub(:for_linter).and_return('enabled' => true)
-
-        HamlLint::ConfigurationLoader.should_receive(:load_file)
-                                     .with('some-config.yml')
-                                     .and_return(config)
-        subject
+      let(:options) do
+        base_options.merge(files: files, reporter: reporter)
       end
-    end
-
-    context 'when `exclude` global config option specifies a list of patterns' do
-      let(:options) { base_options.merge(config: config, files: files) }
-      let(:config) { HamlLint::Configuration.new(config_hash) }
-      let(:config_hash) { { 'exclude' => 'exclude-this-file.slim' } }
 
       before do
-        runner.stub(:extract_applicable_files).and_call_original
+        runner.stub(:collect_lints).and_return([])
       end
 
-      it 'passes the global exclude patterns to the FileFinder' do
-        HamlLint::FileFinder.any_instance
-                            .should_receive(:find)
-                            .with(files, ['exclude-this-file.slim'])
-                            .and_return([])
+      it 'searches for lints in each file' do
+        runner.should_receive(:collect_lints).exactly(files.size).times
         subject
+      end
+
+      context 'when :config_file option is specified' do
+        let(:options) { base_options.merge(config_file: 'some-config.yml') }
+        let(:config) { double('config') }
+
+        it 'loads that specified configuration file' do
+          config.stub(:for_linter).and_return('enabled' => true)
+
+          HamlLint::ConfigurationLoader.should_receive(:load_file)
+                                       .with('some-config.yml')
+                                       .and_return(config)
+          subject
+        end
+      end
+
+      context 'when `exclude` global config option specifies a list of patterns' do
+        let(:options) { base_options.merge(config: config, files: files) }
+        let(:config) { HamlLint::Configuration.new(config_hash) }
+        let(:config_hash) { { 'exclude' => 'exclude-this-file.slim' } }
+
+        before do
+          runner.stub(:extract_applicable_files).and_call_original
+        end
+
+        it 'passes the global exclude patterns to the FileFinder' do
+          HamlLint::FileFinder.any_instance
+                              .should_receive(:find)
+                              .with(files, ['exclude-this-file.slim'])
+                              .and_return([])
+          subject
+        end
+      end
+
+      context 'when there is a Haml parsing error in a file' do
+        let(:files) { %w[inconsistent_indentation.haml] }
+
+        include_context 'isolated environment'
+
+        before do
+          # The runner needs to actually look for files to lint
+          runner.should_receive(:collect_lints).and_call_original
+          haml = "%div\n  %span Hello, world\n\t%span Goodnight, moon"
+
+          `echo "#{haml}" > inconsistent_indentation.haml`
+        end
+
+        it 'adds a syntax lint to the output' do
+          subject.lints.size.should == 1
+
+          lint = subject.lints.first
+          lint.line.should == 2
+          lint.filename.should == 'inconsistent_indentation.haml'
+          lint.message.should match(/^Inconsistent indentation/)
+          lint.severity.should == :error
+
+          linter = lint.linter
+          linter.name.should == 'Syntax'
+        end
       end
     end
 
-    context 'when there is a Haml parsing error in a file' do
-      let(:files) { %w[inconsistent_indentation.haml] }
+    context 'integration tests' do
+      context 'when the fail-fast option is specified with fail-level' do
+        let(:files) { %w[example.haml example2.haml] }
+        let(:options) { base_options.merge(fail_fast: fail_fast, fail_level: :error, files: files) }
 
-      include_context 'isolated environment'
+        include_context 'isolated environment'
 
-      before do
-        # The runner needs to actually look for files to lint
-        runner.should_receive(:collect_lints).and_call_original
+        before do
+          `echo "#my-id Hello\n#my-id World" > example.haml`
+          `echo "-# Hello\n-# World" > example2.haml`
+        end
 
-        `echo "%div\n  %span Hello, world\n\t%span Goodnight, moon" > inconsistent_indentation.haml`
-      end
+        context 'and it is false' do
+          let(:fail_fast) { false }
 
-      it 'adds a syntax lint to the output' do
-        subject.lints.size.should == 1
+          it 'reports the warning but does not halt on it' do
+            subject.lints.size.should == 3
+          end
+        end
 
-        lint = subject.lints.first
-        lint.line.should == 2
-        lint.filename.should == 'inconsistent_indentation.haml'
-        lint.message.should match(/^Inconsistent indentation/)
-        lint.severity.should == :error
+        context 'and it is true' do
+          let(:fail_fast) { true }
 
-        linter = lint.linter
-        linter.name.should == 'Syntax'
+          it 'reports the warning and halts on it' do
+            subject.lints.size.should == 2
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This fixes a bug where fail-level is not respected when used with
fail-fast. That means that if you specify a fail-level that is higher
than the "warning" severity, the program will exit if it encounters an
error that is at the "warning" level.

Closes #215