### PR TITLE
Add a note about ViewLength to v0.26.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Condense generated `.haml-lint_todo.yml` file by using `enabled: false`
   for linters with lints in more than 15 files
 * Fix `UnnecessaryInterpolation` linter for two-character variables
+* Add `ViewLength` linter for checking whether a view has too many lines in it.
 
 ## 0.25.1
 


### PR DESCRIPTION
This adds a note (ex post facto) to the changelog for v0.26.0 about the new ViewLength linter. I updated the release notes for it but figured it should be in here too.

Closes #253