### PR TITLE
Fix nested haml multiline comment unindetation

### DIFF
--- a/lib/haml_lint/ruby_extractor.rb
+++ b/lib/haml_lint/ruby_extractor.rb
@@ -173,7 +173,7 @@ module HamlLint
 
       indent = (' ' * 2 * indent_level)
 
-      @source_lines << indent + code
+      @source_lines << indentation_code(code, indent)
 
       original_line =
         node_or_line.respond_to?(:line) ? node_or_line.line : node_or_line
@@ -185,6 +185,11 @@ module HamlLint
         @line_count += 1
         @source_map[@line_count] = original_line
       end
+    end
+
+    def indentation_code(code, indent)
+      codes = code.split("\n")
+      codes.map { |c| indent + c }.join("\n")
     end
 
     def anonymous_block?(text)

--- a/lib/haml_lint/ruby_extractor.rb
+++ b/lib/haml_lint/ruby_extractor.rb
@@ -173,7 +173,7 @@ module HamlLint
 
       indent = (' ' * 2 * indent_level)
 
-      @source_lines << indentation_code(code, indent)
+      @source_lines << indent_code(code, indent)
 
       original_line =
         node_or_line.respond_to?(:line) ? node_or_line.line : node_or_line
@@ -187,7 +187,7 @@ module HamlLint
       end
     end
 
-    def indentation_code(code, indent)
+    def indent_code(code, indent)
       codes = code.split("\n")
       codes.map { |c| indent + c }.join("\n")
     end

--- a/spec/haml_lint/ruby_extractor_spec.rb
+++ b/spec/haml_lint/ruby_extractor_spec.rb
@@ -313,6 +313,27 @@ describe HamlLint::RubyExtractor do
 
         its(:source_map) { should == { 1 => 1, 2 => 1, 3 => 1, 4 => 1 } }
       end
+
+      context 'with nested' do
+        let(:haml) { <<-HAML }
+          =some_code do
+            -#
+              This is a HAML
+              comment spanning
+              multiple lines
+        HAML
+
+        its(:source) { should == normalize_indent(<<-RUBY).rstrip }
+          some_code do
+            #
+            # This is a HAML
+            # comment spanning
+            # multiple lines
+          end
+        RUBY
+
+        its(:source_map) { should == { 1 => 1, 2 => 2, 3 => 2, 4 => 2, 5 => 2, 6 => 1 } }
+      end
     end
 
     context 'with a block statement' do


### PR DESCRIPTION
This fixes a bug where code like the following:

```haml
- some_code do
  -#
    this is comment
    multiple lines
```

would incorrectly report a lint via the `Layout/CommentIndentation` cop.