### PR TITLE
Make the ClassAttributeWithStaticValue more robust

### DIFF
--- a/lib/haml_lint/linter/class_attribute_with_static_value.rb
+++ b/lib/haml_lint/linter/class_attribute_with_static_value.rb
@@ -43,7 +43,9 @@ module HamlLint
     end
 
     def static_class_attribute_value?(pair)
-      key, value = pair.children
+      return false if (children = pair.children).empty?
+
+      key, value = children
 
       STATIC_TYPES.include?(key.type) &&
         key.children.first.to_sym == :class &&

--- a/spec/haml_lint/linter/class_attribute_with_static_value_spec.rb
+++ b/spec/haml_lint/linter/class_attribute_with_static_value_spec.rb
@@ -68,4 +68,10 @@ describe HamlLint::Linter::ClassAttributeWithStaticValue do
 
     it { should_not report_lint }
   end
+
+  context 'when tag attributes are malformed' do
+    let(:haml) { %(%input{{type: "radio"}, "a" == "b" ? { checked: "checked" } : {}}) }
+
+    it { should_not report_lint }
+  end
 end


### PR DESCRIPTION
Haml is extremely forgiving in its parsing, which leads to strange
errors being thrown by Haml-Lint when the parsing creates something we
weren't expecting. In this case, with a malformed set of attributes that
is still rendered by Haml, Haml-Lint was throwing an error and exiting.

By checking for the correct Haml structure as part of the inspection
predicate, we can prevent this error from happening and still yield
correct results.

Fixes #264