### PR TITLE
Custom Linters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix `ClassAttributeWithStaticValue` to gracefully handle certain malformed
   attributes
+* Add ability to include custom linters
 
 ## 0.27.0
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,38 @@ rational basis, we think that the opinions themselves are less important than
 the fact that `haml-lint` provides us with an automated and low-cost means of
 enforcing consistency.
 
+### Custom Linters
+
+Add the following to your configuration file:
+
+```yaml
+require:
+  - './relative/path/to/my_first_linter.rb'
+  - 'absolute/path/to/my_second_linter.rb'
+```
+
+The files that are referenced by this config should have the following structure:
+
+```ruby
+module HamlLint
+  # MyFirstLinter is the name of the linter in this example, but it can be anything
+  class Linter::MyFirstLinter < Linter
+    include LinterRegistry
+
+    def visit_tag
+      return unless node.tag_name == 'div'
+      record_lint(node, "You're not allowed divs!")
+    end
+  end
+end
+```
+
+For more information on the different types on HAML node, please look through
+the HAML parser code: https://github.com/haml/haml/blob/master/lib/haml/parser.rb
+
+Keep in mind that by default your linter will be disabled by default. So you
+will need to enable it in your configuration file to have it run.
+
 ## Disabling Linters within Source Code
 
 One or more individual linters can be disabled locally in a file by adding

--- a/lib/haml_lint/configuration.rb
+++ b/lib/haml_lint/configuration.rb
@@ -12,8 +12,10 @@ module HamlLint
     # Creates a configuration from the given options hash.
     #
     # @param options [Hash]
-    def initialize(options)
+    def initialize(options, file = nil)
       @hash = options
+      @config_dir = file ? File.dirname(file) : nil
+      resolve_requires
       validate
     end
 
@@ -71,6 +73,19 @@ module HamlLint
           smart_merge(old, new)
         else
           new
+        end
+      end
+    end
+
+    # Requires any extra linters / files specified in the configuration.
+    # String starting with a . are treated as relative paths
+    def resolve_requires
+      relative_require_dir = @config_dir || Dir.pwd
+      Array(@hash['require']).each do |r|
+        if r.start_with?('.')
+          require File.join(relative_require_dir, r)
+        else
+          require r
         end
       end
     end

--- a/lib/haml_lint/configuration_loader.rb
+++ b/lib/haml_lint/configuration_loader.rb
@@ -76,7 +76,7 @@ module HamlLint
           hash['inherits_from'].concat(Array(hash.delete('inherit_from')))
         end
 
-        HamlLint::Configuration.new(hash)
+        HamlLint::Configuration.new(hash, file)
       end
 
       # Returns a list of possible configuration files given the context of the


### PR DESCRIPTION
There is a fair amount of specific domain knowledge needed to write a linter (what HAML node you're looking for etc.) but we should at least allow people to go ahead and include their own custom linters. I previously forked this repo to add my custom linters, but I am very eager to remove that fork and just put the linters in the codebase.

This approach was very heavily influenced by Rubocop's `require` configuration.

Resolves https://github.com/brigade/haml-lint/issues/96