### PR TITLE
Absolute path support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   attributes
 * Add ability to include custom linters
 * Drop support for Ruby 2.1
+* Fix passing absolute filenames ignoring relative path excludes config
 
 ## 0.27.0
 

--- a/spec/haml_lint/utils_spec.rb
+++ b/spec/haml_lint/utils_spec.rb
@@ -2,35 +2,60 @@ require 'spec_helper'
 require 'securerandom'
 
 describe HamlLint::Utils do
-  describe 'any_glob_matches?' do
-    let(:file) { 'match-file.txt' }
+  shared_examples('any_glob_matches? tests') do |path_type, file|
     subject { described_class.any_glob_matches?(globs, file) }
 
-    context 'when a single matching glob is given' do
-      let(:globs) { 'match-*.txt' }
+    context "with a #{path_type} path" do
+      context 'when a single matching glob is given' do
+        let(:globs) { 'match-*.txt' }
 
-      it { should == true }
-    end
+        it { should == true }
+      end
 
-    context 'when a single non-matching glob is given' do
-      let(:globs) { 'other-*.txt' }
-
-      it { should == false }
-    end
-
-    context 'when a list of globs is given' do
-      context 'and none of them match' do
-        let(:globs) { ['who.txt', 'nope*.txt', 'nomatch-*.txt'] }
+      context 'when a single non-matching glob is given' do
+        let(:globs) { 'other-*.txt' }
 
         it { should == false }
       end
 
-      context 'and one of them match' do
-        let(:globs) { ['who.txt', 'nope*.txt', 'match-*.txt'] }
+      context 'when a single matching relative path is given' do
+        let(:globs) { 'match-file.txt' }
 
         it { should == true }
       end
+
+      context 'when a single matching absolute path is given' do
+        let(:globs) { File.expand_path('match-file.txt', Dir.pwd) }
+
+        it { should == true }
+      end
+
+      context 'when a single non-matching path is given' do
+        let(:globs) { 'match-file.txt' }
+
+        it { should == true }
+      end
+
+      context 'when a list of globs is given' do
+        context 'and none of them match' do
+          let(:globs) { ['who.txt', 'nope*.txt', 'nomatch-*.txt'] }
+
+          it { should == false }
+        end
+
+        context 'and one of them match' do
+          let(:globs) { ['who.txt', 'nope*.txt', 'match-*.txt'] }
+
+          it { should == true }
+        end
+      end
     end
+  end
+
+  describe 'any_glob_matches?' do
+    include_examples 'any_glob_matches? tests', 'relative', 'match-file.txt'
+    include_examples 'any_glob_matches? tests', 'absolute',
+                     File.expand_path('match-file.txt', Dir.pwd)
   end
 
   describe '.extract_interpolated_values' do


### PR DESCRIPTION
Fix passing absolute filenames ignoring relative path excludes config. Some tools like https://github.com/okonet/lint-staged send absolute path names to the commands specified, this causes haml-lint violations when there shouldn't be any.

This PR changes `any_glob_matches?` to check both the provided filename against the ignores, along with the other of the absolute and relative path names (so absolute in the case that a relative path is passed, or relative in the case an absolute path is passed).

### Replication

Can be shown through the following test:

```yaml
# .haml-lint.yml
linters:
  InstanceVariables:
    exclude:
      - 'app/views/_my_view.html.haml'
```

```haml
-# app/views/_my_view.html.haml
= @my_ivar
```

```bash
> haml-lint app/views/_my_view.html.haml
1 file inspected, 0 lints detected

> haml-lint /path/to/repo/app/views/_my_view.html.haml
/path/to/repo/app/views/_my_view.html.haml:1 [W] InstanceVariables: Avoid using instance variables in partials views

1 file inspected, 1 lints detected
```