### PR TITLE
Allow multiline nodes to work with global linters like LineLength

### DIFF
--- a/lib/haml_lint/tree/node.rb
+++ b/lib/haml_lint/tree/node.rb
@@ -102,7 +102,10 @@ module HamlLint::Tree
     def line_numbers
       return (line..line) unless @value && text
 
-      (line..line + lines.count)
+      end_line = line + lines.count
+      end_line = nontrivial_end_line if line == end_line
+
+      (line..end_line)
     end
 
     # The previous node to be traversed in the tree.
@@ -151,6 +154,19 @@ module HamlLint::Tree
     end
 
     private
+
+    # Discovers the end line of the node when there are no lines.
+    #
+    # @return [Integer] the end line of the node
+    def nontrivial_end_line
+      if (last_child = children.last)
+        last_child.line_numbers.end - 1
+      elsif successor
+        successor.line_numbers.begin - 1
+      else
+        @document.source_lines.count
+      end
+    end
 
     # The siblings of this node within the tree.
     #

--- a/spec/haml_lint/linter/line_length_spec.rb
+++ b/spec/haml_lint/linter/line_length_spec.rb
@@ -47,4 +47,19 @@ describe HamlLint::Linter::LineLength do
 
     it { should report_lint line: 6 }
   end
+
+  context 'when there is a directive on the line before a multiline pipe' do
+    let(:haml) do
+      <<-HAML
+        -# haml-lint:disable LineLength
+        %p{ |
+          'data-test' => link_to 'Foobar', i_need_to_make_this_line_longer_path, class: 'button alert' } |
+        -# haml-lint:enable LineLength
+        %p Another really long line that should report a lint for line length because it is no longer disabled
+      HAML
+    end
+
+    it { should_not report_lint line: 3 }
+    it { should report_lint line: 5 }
+  end
 end

--- a/spec/haml_lint/tree/node_spec.rb
+++ b/spec/haml_lint/tree/node_spec.rb
@@ -151,6 +151,74 @@ describe HamlLint::Tree::Node do
     it { should == '#<HamlLint::Tree::RootNode>' }
   end
 
+  describe '#line_numbers' do
+    subject { document.tree.children.first.line_numbers }
+
+    context 'for a node with a body' do
+      let(:haml) do
+        <<-HAML
+          %p
+            This is the body of the paragraph tag
+            and it goes over multiple lines.
+        HAML
+      end
+
+      it { should == (1..3) }
+
+      context 'with a successor' do
+        let(:haml) do
+          <<-HAML
+            %p
+              This is the body of the paragraph tag
+              and it goes over multiple lines.
+            %p This is a successor
+          HAML
+        end
+
+        it { should == (1..3) }
+      end
+    end
+
+    context 'for a multiline node' do
+      let(:haml) do
+        <<-HAML
+          %p{ |
+            'data-test' => 'This is a multiline node' } |
+        HAML
+      end
+
+      it { should == (1..2) }
+
+      context 'with a successor' do
+        let(:haml) do
+          <<-HAML
+            %p{ |
+              'data-test' => 'This is a multiline node' } |
+            %p This is a successor
+          HAML
+        end
+
+        it { should == (1..2) }
+      end
+    end
+
+    context 'for a single-line node without a successor' do
+      let(:haml) do
+        <<-HAML
+          %p This is a single-line node
+        HAML
+      end
+
+      it { should == (1..1) }
+    end
+
+    context 'for a node with a successor and no body' do
+      let(:haml) { '%p' }
+
+      it { should == (1..1) }
+    end
+  end
+
   describe '#predecessor' do
     subject { document.tree.find { |node| node.type == :haml_comment }.predecessor }
 

--- a/spec/support/matchers/report_lint.rb
+++ b/spec/support/matchers/report_lint.rb
@@ -30,8 +30,20 @@ RSpec::Matchers.define :report_lint do |options|
       end
   end
 
-  failure_message_when_negated do |_linter|
-    'expected that a lint would not be reported'
+  failure_message_when_negated do |linter|
+    message = ['expected that a lint would not be reported, but reported ']
+
+    message <<
+      case linter.lints.count
+      when 1 then "1 lint:\n"
+      else "#{linter.lints.count} lints:\n"
+      end
+
+    linter.lints.each do |lint|
+      message << "  - Line #{lint.line}: #{lint.message}"
+    end
+
+    message.join
   end
 
   description do


### PR DESCRIPTION
Multiline nodes (particularly those using the [multiline pipe] feature
of Haml) were only reporting their beginning line in their
`#line_numbers` attribute. This meant that disabling linters via
directives was not working as expected for multiline nodes, leading to
a confusing experience for directive users.

By looking at the lines of a node, its children, its successor, and,
when necessary, the end of the document itself, we can give a more
precise end line for each node, which improves the behavior of
directives.

Fixes #276

---

As part of this work, I found room to improve the refutation behavior of 
the `report_lint` matcher to give more information when your test fails.
That is included in the first commit.

[multiline pipe]: http://haml.info/docs/yardoc/file.REFERENCE.html#multiline