### PR TITLE
Fix a silent ignore of the config file during Rake

### DIFF
--- a/lib/haml_lint/rake_task.rb
+++ b/lib/haml_lint/rake_task.rb
@@ -131,6 +131,7 @@ module HamlLint
     def parse_args
       cli_args = config ? ['--config', config] : []
       cli_args.concat(['--fail-level', fail_level]) if fail_level
+      cli_args
     end
   end
 end

--- a/spec/haml_lint/rake_task_spec.rb
+++ b/spec/haml_lint/rake_task_spec.rb
@@ -4,7 +4,14 @@ require 'tempfile'
 
 describe HamlLint::RakeTask do
   before(:all) do
+    config =
+      Tempfile.new(%w[my-haml-lint.yml]).tap do |f|
+        f.write("linters:\n  MultilinePipe:\n    enabled: false\n  RuboCop:\n    enabled: false")
+        f.close
+      end
+
     HamlLint::RakeTask.new do |t|
+      t.config = config.path
       t.fail_level = 'warning'
       t.quiet = true
     end
@@ -37,6 +44,14 @@ describe HamlLint::RakeTask do
 
     it 'raises an error' do
       expect { run_task }.to raise_error RuntimeError
+    end
+  end
+
+  context 'with a config file that disables a linter' do
+    let(:haml) { "%p{ |\n     'data-lint' => 'Will be raised without config' } |\n" }
+
+    it 'executes without error' do
+      expect { run_task }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
We were accidentally dropping any configuration file that was configured
for the Rake task unless the fail level was also specified. Now, we're
correctly keeping the configuration file setting, even when we do not
specify a fail level.

Fixes #277