### PR TITLE
Use the default configuration for auto-gen-config

### DIFF
--- a/lib/haml_lint/runner.rb
+++ b/lib/haml_lint/runner.rb
@@ -57,7 +57,9 @@ module HamlLint
     # @param options [Hash]
     # @return [HamlLint::Configuration]
     def load_applicable_config(options)
-      if options[:config_file]
+      if options[:auto_gen_config]
+        HamlLint::ConfigurationLoader.default_configuration
+      elsif options[:config_file]
         HamlLint::ConfigurationLoader.load_file(options[:config_file])
       elsif options[:config]
         options[:config]


### PR DESCRIPTION
Instead of using the configuration that includes the previously found
lints by `--auto-gen-config`, we should use the default configuration to
make sure the todo file isn't used to ignore lints for the subsequent
run.

It wasn't clear how to add a test for this since the CLI specs aren't the
place for the integration tests; those live in the Runner specs. But the
Runner does what the CLI tells it to do, so it's a bit of a dance.

Fixes #256 