### PR TITLE
Disable the BundleCheck linter

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,7 +1,4 @@
 PreCommit:
-  BundleCheck:
-    enabled: true
-
   ExecutePermissions:
     enabled: true
     exclude:


### PR DESCRIPTION
This seems to be broken on Travis due to the Gemfile.lock containing the
Ruby version across the different runs. Since we do not commit the
Gemfile.lock file (due to this being a library), this check doesn't seem
to be needed.

Does this make sense?