### PR TITLE
allow ViewLength linter be disabled inline

### DIFF
--- a/lib/haml_lint/linter/view_length.rb
+++ b/lib/haml_lint/linter/view_length.rb
@@ -7,11 +7,12 @@ module HamlLint
 
     DummyNode = Struct.new(:line)
 
-    def visit_root(_root)
+    def visit_root(root)
       max = config['max']
       line_count = document.source_lines.count
+      node = root.children.first
 
-      if line_count > max
+      if line_count > max && !node.disabled?(self)
         record_lint(DummyNode.new(0), format(MSG, line_count, max))
       end
     end

--- a/spec/haml_lint/linter/view_length_spec.rb
+++ b/spec/haml_lint/linter/view_length_spec.rb
@@ -20,4 +20,10 @@ RSpec.describe HamlLint::Linter::ViewLength do
 
     it { should report_lint line: 0 }
   end
+
+  context 'over the line limit with linter disabled' do
+    let(:haml) { "-# haml-lint:disable ViewLength\n#{"a\n" * 150}" }
+
+    it { should_not report_lint }
+  end
 end


### PR DESCRIPTION
This pull request allows a user to disable the ViewLength linter on the opening line in a file. Tests are included.