### PR TITLE
Ignore rubocop Layout/AlignHash in default config

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -91,6 +91,7 @@ linters:
       - Lint/BlockAlignment
       - Lint/EndAlignment
       - Lint/Void
+      - Layout/AlignHash
       - Layout/AlignParameters
       - Layout/ElseAlignment
       - Layout/EndOfLine


### PR DESCRIPTION
If ruby calls span multiple lines, the extracted ruby code
doesn't have the original indentation, so the Layout/AlignHash
cop will give wrong reports

Example:

```
 $('#modal').html("#{escape_javascript(render(partial: 'submit_request_dialog',
                                              locals: { project: @project, package: @package,
                                              revision: @revision, target_project: @tprj, target_package: @tpkg,
                                              description: @description, cleanup_source: @cleanup_source }))}")
```

Becomes extracted:

```
escape_javascript(render(partial: 'submit_request_dialog',
                                             locals: { project: @project, package: @package,
                                             revision: @revision, target_project: @tprj, target_package: @tpkg,
                                             description: @description, cleanup_source: @cleanup_source }))
```

And rubocop would complain about 'Align the elements of a hash literal
if they span more than one line.'