### PR TITLE
CI against Ruby 2.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.3.8
   - 2.4.5
   - 2.5.3
-  - 2.6.0
+  - 2.6.1
 
 gemfile:
   - gemfiles/haml4.gemfile


### PR DESCRIPTION
Ruby 2.6.1 has been released and this Ruby version is available on Travis CI.
https://www.ruby-lang.org/en/news/2019/01/30/ruby-2-6-1-released