### PR TITLE
Specify `--require spec_helper` in .rspec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --color
+--require spec_helper

--- a/spec/haml_lint/adapter_spec.rb
+++ b/spec/haml_lint/adapter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe HamlLint::Adapter do
   describe '.detect_class' do
     subject { described_class.detect_class }

--- a/spec/haml_lint/cli_spec.rb
+++ b/spec/haml_lint/cli_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'haml_lint/cli'
 
 describe HamlLint::CLI do

--- a/spec/haml_lint/comment_configuration_spec.rb
+++ b/spec/haml_lint/comment_configuration_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe HamlLint::CommentConfiguration do
   subject(:config) { described_class.new(node) }
 

--- a/spec/haml_lint/configuration_loader_spec.rb
+++ b/spec/haml_lint/configuration_loader_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::ConfigurationLoader do
   describe '.load_applicable_config' do
     subject { described_class.load_applicable_config }

--- a/spec/haml_lint/configuration_spec.rb
+++ b/spec/haml_lint/configuration_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Configuration do
   let(:config) { HamlLint::ConfigurationLoader.default_configuration }
 

--- a/spec/haml_lint/directive_spec.rb
+++ b/spec/haml_lint/directive_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe HamlLint::Directive do
   subject(:directive) { described_class.new }
 

--- a/spec/haml_lint/document_spec.rb
+++ b/spec/haml_lint/document_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Document do
   let(:config) { double }
 

--- a/spec/haml_lint/file_finder_spec.rb
+++ b/spec/haml_lint/file_finder_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::FileFinder do
   let(:config) { double }
   let(:excluded_patterns) { [] }

--- a/spec/haml_lint/haml_visitor_spec.rb
+++ b/spec/haml_lint/haml_visitor_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::HamlVisitor do
   describe '#visit' do
     let(:options) do

--- a/spec/haml_lint/linter/alignment_tabs_spec.rb
+++ b/spec/haml_lint/linter/alignment_tabs_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe HamlLint::Linter::AlignmentTabs do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/alt_text_spec.rb
+++ b/spec/haml_lint/linter/alt_text_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::AltText do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/class_attribute_with_static_value_spec.rb
+++ b/spec/haml_lint/linter/class_attribute_with_static_value_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::ClassAttributeWithStaticValue do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/classes_before_ids_spec.rb
+++ b/spec/haml_lint/linter/classes_before_ids_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::ClassesBeforeIds do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/consecutive_comments_spec.rb
+++ b/spec/haml_lint/linter/consecutive_comments_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::ConsecutiveComments do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/consecutive_silent_scripts_spec.rb
+++ b/spec/haml_lint/linter/consecutive_silent_scripts_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::ConsecutiveSilentScripts do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/empty_object_reference_spec.rb
+++ b/spec/haml_lint/linter/empty_object_reference_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::EmptyObjectReference do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/empty_script_spec.rb
+++ b/spec/haml_lint/linter/empty_script_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::EmptyScript do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/final_newline_spec.rb
+++ b/spec/haml_lint/linter/final_newline_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::FinalNewline do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/html_attributes_spec.rb
+++ b/spec/haml_lint/linter/html_attributes_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::HtmlAttributes do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/id_names_spec.rb
+++ b/spec/haml_lint/linter/id_names_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe HamlLint::Linter::IdNames do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/implicit_div_spec.rb
+++ b/spec/haml_lint/linter/implicit_div_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::ImplicitDiv do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/indentation_spec.rb
+++ b/spec/haml_lint/linter/indentation_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::Indentation do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/inline_styles_spec.rb
+++ b/spec/haml_lint/linter/inline_styles_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe HamlLint::Linter::InlineStyles do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/instance_variables_spec.rb
+++ b/spec/haml_lint/linter/instance_variables_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe HamlLint::Linter::InstanceVariables do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/leading_comment_space_spec.rb
+++ b/spec/haml_lint/linter/leading_comment_space_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::LeadingCommentSpace do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/line_length_spec.rb
+++ b/spec/haml_lint/linter/line_length_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::LineLength do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/multiline_pipe_spec.rb
+++ b/spec/haml_lint/linter/multiline_pipe_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::MultilinePipe do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/multiline_script_spec.rb
+++ b/spec/haml_lint/linter/multiline_script_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::MultilineScript do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/object_reference_attributes_spec.rb
+++ b/spec/haml_lint/linter/object_reference_attributes_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::ObjectReferenceAttributes do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/repeated_id_spec.rb
+++ b/spec/haml_lint/linter/repeated_id_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe HamlLint::Linter::RepeatedId do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/rubocop_spec.rb
+++ b/spec/haml_lint/linter/rubocop_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::RuboCop do
   it 'exhaustively maps RuboCop severity levels to HamlLint severity levels' do
     ::RuboCop::Cop::Severity::NAMES.each do |name|

--- a/spec/haml_lint/linter/ruby_comments_spec.rb
+++ b/spec/haml_lint/linter/ruby_comments_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::RubyComments do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/space_before_script_spec.rb
+++ b/spec/haml_lint/linter/space_before_script_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::SpaceBeforeScript do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/space_inside_hash_attributes_spec.rb
+++ b/spec/haml_lint/linter/space_inside_hash_attributes_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::SpaceInsideHashAttributes do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/tag_name_spec.rb
+++ b/spec/haml_lint/linter/tag_name_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::TagName do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/trailing_whitespace_spec.rb
+++ b/spec/haml_lint/linter/trailing_whitespace_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::TrailingWhitespace do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/unnecessary_interpolation_spec.rb
+++ b/spec/haml_lint/linter/unnecessary_interpolation_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::UnnecessaryInterpolation do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/unnecessary_string_output_spec.rb
+++ b/spec/haml_lint/linter/unnecessary_string_output_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter::UnnecessaryStringOutput do
   include_context 'linter'
 

--- a/spec/haml_lint/linter/view_length_spec.rb
+++ b/spec/haml_lint/linter/view_length_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe HamlLint::Linter::ViewLength do
   include_context 'linter'
 

--- a/spec/haml_lint/linter_registry_spec.rb
+++ b/spec/haml_lint/linter_registry_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::LinterRegistry do
   context 'when including the LinterRegistry module' do
     it 'adds the linter to the set of registered linters' do

--- a/spec/haml_lint/linter_selector_spec.rb
+++ b/spec/haml_lint/linter_selector_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::LinterSelector do
   let(:options) { {} }
   let(:config) { HamlLint::ConfigurationLoader.load_hash(config_hash) }

--- a/spec/haml_lint/linter_spec.rb
+++ b/spec/haml_lint/linter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Linter do
   let(:linter_class) do
     Class.new(described_class) do

--- a/spec/haml_lint/logger_spec.rb
+++ b/spec/haml_lint/logger_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Logger do
   let(:io)     { StringIO.new }
   let(:logger) { described_class.new(io) }

--- a/spec/haml_lint/options_spec.rb
+++ b/spec/haml_lint/options_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 require 'haml_lint/options'
 
 describe HamlLint::Options do

--- a/spec/haml_lint/rake_task_spec.rb
+++ b/spec/haml_lint/rake_task_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'haml_lint/rake_task'
 require 'tempfile'
 

--- a/spec/haml_lint/report_spec.rb
+++ b/spec/haml_lint/report_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe HamlLint::Report do
   let(:fail_level) { :warning }
   let(:filenames) { ['some-filename.haml'] }

--- a/spec/haml_lint/reporter/checkstyle_reporter_spec.rb
+++ b/spec/haml_lint/reporter/checkstyle_reporter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Reporter::CheckstyleReporter do
   describe '#display_report' do
     let(:io) { StringIO.new }

--- a/spec/haml_lint/reporter/default_reporter_spec.rb
+++ b/spec/haml_lint/reporter/default_reporter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Reporter::DefaultReporter do
   let(:filenames) { %w[some-filename.haml] }
   let(:io) { StringIO.new }

--- a/spec/haml_lint/reporter/disabled_config_reporter_spec.rb
+++ b/spec/haml_lint/reporter/disabled_config_reporter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe HamlLint::Reporter::DisabledConfigReporter do
   let(:config)   { File.read('.haml-lint_todo.yml') }
   let(:files)    { ['some-filename.haml'] }

--- a/spec/haml_lint/reporter/json_reporter_spec.rb
+++ b/spec/haml_lint/reporter/json_reporter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Reporter::JsonReporter do
   describe '#display_report' do
     let(:io) { StringIO.new }

--- a/spec/haml_lint/reporter/progress_reporter_spec.rb
+++ b/spec/haml_lint/reporter/progress_reporter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe HamlLint::Reporter::ProgressReporter do
   let(:files)    { ['some-filename.haml'] }
   let(:io)       { StringIO.new }

--- a/spec/haml_lint/reporter_spec.rb
+++ b/spec/haml_lint/reporter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Reporter do
   let(:reporter) { HamlLint::Reporter.new(double) }
 

--- a/spec/haml_lint/ruby_extractor_spec.rb
+++ b/spec/haml_lint/ruby_extractor_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::RubyExtractor do
   let(:extractor) { described_class.new }
 

--- a/spec/haml_lint/ruby_parser_spec.rb
+++ b/spec/haml_lint/ruby_parser_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::RubyParser do
   describe '#parse' do
     subject { super().parse(source) }

--- a/spec/haml_lint/runner_spec.rb
+++ b/spec/haml_lint/runner_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Runner do
   let(:base_options) { { reporter: reporter } }
   let(:options) { base_options }

--- a/spec/haml_lint/severity_spec.rb
+++ b/spec/haml_lint/severity_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe HamlLint::Severity do
   let(:name) { nil }
 

--- a/spec/haml_lint/tree/haml_comment_node_spec.rb
+++ b/spec/haml_lint/tree/haml_comment_node_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Tree::HamlCommentNode do
   let(:options) do
     {

--- a/spec/haml_lint/tree/node_spec.rb
+++ b/spec/haml_lint/tree/node_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Tree::Node do
   let(:options) do
     {

--- a/spec/haml_lint/tree/root_node_spec.rb
+++ b/spec/haml_lint/tree/root_node_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe HamlLint::Tree::RootNode do
   describe '#node_for_line' do
     let(:document) { HamlLint::Document.new(haml, config: {}) }

--- a/spec/haml_lint/tree/tag_node_spec.rb
+++ b/spec/haml_lint/tree/tag_node_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HamlLint::Tree::TagNode do
   let(:options) do
     {

--- a/spec/haml_lint/utils_spec.rb
+++ b/spec/haml_lint/utils_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'securerandom'
 
 describe HamlLint::Utils do


### PR DESCRIPTION
Require `spec_helper` automatically in `*_spec.rb`.

Refer: https://github.com/rspec/rspec/wiki#rspec