### PR TITLE
Allow comment banners with LeadingCommentSpace rule

### DIFF
--- a/lib/haml_lint/linter/leading_comment_space.rb
+++ b/lib/haml_lint/linter/leading_comment_space.rb
@@ -6,7 +6,7 @@ module HamlLint
     def visit_haml_comment(node)
       # Skip if the node spans multiple lines starting on the second line,
       # or starts with a space
-      return if node.text =~ /\A(\s*|\s+\S.*)$/
+      return if node.text =~ /\A#*(\s*|\s+\S.*)$/
 
       record_lint(node, 'Comment should have a space after the `#`')
     end

--- a/spec/haml_lint/linter/leading_comment_space_spec.rb
+++ b/spec/haml_lint/linter/leading_comment_space_spec.rb
@@ -34,4 +34,14 @@ describe HamlLint::Linter::LeadingCommentSpace do
 
     it { should_not report_lint }
   end
+
+  context 'when a comment has a banner line' do
+    let(:haml) { <<-HAML }
+      -######################
+      -# Important section! #
+      -######################
+    HAML
+
+    it { should_not report_lint }
+  end
 end


### PR DESCRIPTION
In a few of our haml templates we've ended up with banner-comments like:

```haml
-############################
-# here's an important bit! #
-############################
```

Or simply using a single line of `-#############` to break sections up a bit.

These are currently not allowed according to haml-lint's LeadingCommentSpace (although rubocop _does_ allow them).  WDYT to this change?
