### PR TITLE
Allow overriding the exclude-limit in DisabledConfigReporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,12 @@ as exclusions. You can then add `inherits_from: .haml-lint_todo.yml` to your
 `.haml-lint.yml` configuration file to ensure these exclusions are used whenever
 you call `haml-lint`.
 
+By default, any rules with more than 15 violations will be disabled in the todo-file.
+You can increase this limit with the `exclude-limit` option:
+
+    haml-lint --auto-gen-config --exclude-limit 100
+
+
 ## Editor Integration
 
 ### Vim

--- a/lib/haml_lint/cli.rb
+++ b/lib/haml_lint/cli.rb
@@ -92,7 +92,7 @@ module HamlLint
     # @return [HamlLint::Reporter]
     def reporter_from_options(options)
       if options[:auto_gen_config]
-        HamlLint::Reporter::DisabledConfigReporter.new(log)
+        HamlLint::Reporter::DisabledConfigReporter.new(log, limit: options[:auto_gen_exclude_limit] || 15) # rubocop:disable Metrics/LineLength
       else
         options.fetch(:reporter, HamlLint::Reporter::DefaultReporter).new(log)
       end

--- a/lib/haml_lint/options.rb
+++ b/lib/haml_lint/options.rb
@@ -37,6 +37,11 @@ module HamlLint
         @options[:auto_gen_config] = true
       end
 
+      parser.on('--auto-gen-exclude-limit limit', Integer,
+                'Number of failures to allow in the TODO list before the entire rule is excluded') do |limit| # rubocop:disable Metrics/LineLength
+        @options[:auto_gen_exclude_limit] = limit
+      end
+
       parser.on('-i', '--include-linter linter,...', Array,
                 'Specify which linters you want to run') do |linters|
         @options[:included_linters] = linters

--- a/lib/haml_lint/reporter/disabled_config_reporter.rb
+++ b/lib/haml_lint/reporter/disabled_config_reporter.rb
@@ -23,10 +23,11 @@ module HamlLint
     # Create the reporter that will display the report and write the config.
     #
     # @param _log [HamlLint::Logger]
-    def initialize(_log)
-      super
+    def initialize(log, limit: 15)
+      super(log)
       @linters_with_lints = Hash.new { |hash, key| hash[key] = [] }
       @linters_lint_count = Hash.new(0)
+      @exclude_limit = limit
     end
 
     # A hash of linters with the files that have that type of lint.
@@ -40,6 +41,11 @@ module HamlLint
     # @return [Hash<String, Array<String>>] a Hash with linter name keys and file
     #   name list values
     attr_reader :linters_with_lints
+
+    # Number of offenses to allow before simply disabling the linter
+    #
+    # @return [Integer] file exclude limit
+    attr_reader :exclude_limit
 
     # Prints the standard progress reporter output and writes the new config file.
     #
@@ -97,7 +103,7 @@ module HamlLint
         output << "  #{linter}:"
         # disable the linter when there are many files with offenses.
         # exclude the affected files otherwise.
-        if files.count > 15
+        if files.count > exclude_limit
           output << '    enabled: false'
         else
           output << '    exclude:'

--- a/spec/haml_lint/reporter/disabled_config_reporter_spec.rb
+++ b/spec/haml_lint/reporter/disabled_config_reporter_spec.rb
@@ -111,6 +111,28 @@ RSpec.describe HamlLint::Reporter::DisabledConfigReporter do
             '    enabled: false'
           ].join("\n")
       end
+
+      context 'when auto-gen-exclude-limit is specified' do
+        let(:reporter) { described_class.new(logger, limit: 1) }
+
+        it 'excludes linters whose offense-count is greater than the limit' do
+          subject
+          config.should ==
+            [
+              described_class::HEADING,
+              '',
+              'linters:',
+              '',
+              '  # Offense count: 3',
+              '  SomeLinter:',
+              '    enabled: false',
+              '',
+              '  # Offense count: 16',
+              '  OtherLinter:',
+              '    enabled: false'
+            ].join("\n")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
It's currently hard-coded to 15.  WDYT to this change?